### PR TITLE
Modify sysDescription file location

### DIFF
--- a/src/sonic_ax_impl/bin/sysDescr_pass.py
+++ b/src/sonic_ax_impl/bin/sysDescr_pass.py
@@ -81,7 +81,7 @@ elif command == '-g' and oid != myoid:
     sys.stdout.flush()
     sys.exit()
 
-filepath = "/etc/ssw/sysDescription"
+filepath = "/etc/snmp/sysDescription"
 sysDescription = "SONiC (unknown version) - HwSku (unknown) - Distribution (unknown) - Kernel (unknown)"
 
 try:


### PR DESCRIPTION
Use a snmp-specific location instead of historical shared location