### PR TITLE
[SNMP Counters]: Update interface list periodically

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -11,6 +11,10 @@ Update interval between update runs (in seconds).
 """
 DEFAULT_UPDATE_FREQUENCY = 5
 
+"""
+Interval between reinit runs (in seconds).
+"""
+DEFAULT_REINIT_RATE = 60
 
 class MIBUpdater:
     """
@@ -20,15 +24,29 @@ class MIBUpdater:
     def __init__(self):
         self.run_event = asyncio.Event()
         self.frequency = DEFAULT_UPDATE_FREQUENCY
+        self.update_counter = 0
+        self.reinit_rate = DEFAULT_REINIT_RATE // DEFAULT_UPDATE_FREQUENCY
 
     async def start(self):
         # Run the update while we are allowed
         while self.run_event.is_set():
+            # reinit internal structures
+            if self.update_counter > self.reinit_rate:
+                self.reinit_data()
+                update_counter = 0
+            else:
+                update_counter += 1
             # run the background update task
             self.update_data()
             # wait based on our update frequency before executing again.
             # randomize to avoid concurrent update storms.
             await asyncio.sleep(self.frequency + random.randint(-2, 2))
+
+    def reinit_data(self):
+        """
+        Reinit task. Children may override this method.
+        """
+        return
 
     def update_data(self):
         """

--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -33,9 +33,9 @@ class MIBUpdater:
             # reinit internal structures
             if self.update_counter > self.reinit_rate:
                 self.reinit_data()
-                update_counter = 0
+                self.update_counter = 0
             else:
-                update_counter += 1
+                self.update_counter += 1
             # run the background update task
             self.update_data()
             # wait based on our update frequency before executing again.

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -78,15 +78,14 @@ def config(**kwargs):
     global redis_kwargs
     redis_kwargs = {k:v for (k,v) in kwargs.items() if k in ['unix_socket_path', 'host', 'port']}
 
-def init_counters_db():
+def init_db():
     """
-    Connects CountersDB
+    Connects to DB
     :return: db_conn
     """
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
     db_conn = SonicV2Connector(**redis_kwargs)
-    db_conn.connect(COUNTERS_DB)
 
     return db_conn
 
@@ -96,6 +95,10 @@ def init_sync_d_interface_tables(db_conn):
     Initializes interface maps for SyncD-connected MIB(s).
     :return: tuple(if_name_map, if_id_map, oid_map, if_alias_map)
     """
+
+    # Make sure we're connected to COUNTERS_DB
+    db_conn.connect(COUNTERS_DB)
+
     # { if_name (SONiC) -> sai_id }
     # ex: { "Ethernet76" : "1000000000023" }
     if_name_map = db_conn.get_all(COUNTERS_DB, COUNTERS_PORT_NAME_MAP, blocking=True)

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -31,26 +31,32 @@ class LLDPUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
+        self.reinit_data()
+
+        # cache of interface counters
+        # { sai_id -> { 'counter': 'value' } }
+        self.lldp_counters = {}
+        # call our update method once to "seed" data before the "Agent" starts accepting requests.
+        self.update_data()
+
+    def reinit_data(self):
+        """
+        Subclass update interface information
+        """
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
         self.oid_name_map = mibs.init_sync_d_interface_tables()
 
+    def update_data(self):
+        """
+        Subclass update data routine. Updates available LLDP counters.
+        """
+
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
 
-        # cache of interface counters
-        # { sai_id -> { 'counter': 'value' } }
-        self.lldp_counters = {}
-        self.sai_ids = []
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
-
-    def update_data(self):
-        """
-        Subclass update data routine. Updates available sai_ids and LLDP counters.
-        """
         self.lldp_counters = {}
         for if_name in self.if_name_map:
             lldp_kvs = self.db_conn.get_all(mibs.APPL_DB, mibs.lldp_entry_table(if_name))

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -30,7 +30,7 @@ class LLDPUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
 
-        self.db_conn = mibs.init_counters_db()
+        self.db_conn = mibs.init_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -47,7 +47,7 @@ class LLDPUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -30,7 +30,7 @@ class LLDPUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
 
-        self.db_conn, \
+        self.db_conn = mibs.init_counters_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -93,7 +93,7 @@ class IpMib(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.4'):
 class InterfacesUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
-        self.db_conn = mibs.init_counters_db()
+        self.db_conn = mibs.init_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -114,7 +114,7 @@ class InterfacesUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -94,11 +94,7 @@ class InterfacesUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
-        self.if_name_map, \
-        self.if_alias_map, \
-        self.if_id_map, \
-        self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.reinit_data()
 
         self.lag_name_if_name_map = {}
         self.if_name_lag_name_map = {}
@@ -109,6 +105,16 @@ class InterfacesUpdater(MIBUpdater):
         self.if_range = []
         # call our update method once to "seed" data before the "Agent" starts accepting requests.
         self.update_data()
+
+    def reinit_data(self):
+        """
+        Subclass update interface information
+        """
+        self.if_name_map, \
+        self.if_alias_map, \
+        self.if_id_map, \
+        self.oid_sai_map, \
+        self.oid_name_map = mibs.init_sync_d_interface_tables()
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -93,7 +93,7 @@ class IpMib(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.4'):
 class InterfacesUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
-        self.db_conn, \
+        self.db_conn = mibs.init_counters_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -67,7 +67,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -48,7 +48,7 @@ class InterfaceMIBUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
 
-        self.db_conn, \
+        self.db_conn = mibs.init_counters_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -48,7 +48,7 @@ class InterfaceMIBUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
 
-        self.db_conn = mibs.init_counters_db()
+        self.db_conn = mibs.init_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -49,11 +49,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
-        self.if_name_map, \
-        self.if_alias_map, \
-        self.if_id_map, \
-        self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.reinit_data()
 
         self.lag_name_if_name_map = {}
         self.if_name_lag_name_map = {}
@@ -62,6 +58,16 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_counters = {}
         self.if_range = []
         self.update_data()
+
+    def reinit_data(self):
+        """
+        Subclass update interface information
+        """
+        self.if_name_map, \
+        self.if_alias_map, \
+        self.if_id_map, \
+        self.oid_sai_map, \
+        self.oid_name_map = mibs.init_sync_d_interface_tables()
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -12,7 +12,7 @@ class RouteUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.tos = 0 # ipCidrRouteTos
-        self.db_conn = mibs.init_counters_db()
+        self.db_conn = mibs.init_db()
         self.update_data()
 
     def update_data(self):

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -12,7 +12,7 @@ class RouteUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.tos = 0 # ipCidrRouteTos
-        self.db_conn, _, _, _, _, _ = mibs.init_sync_d_interface_tables()
+        self.db_conn = mibs.init_counters_db()
         self.update_data()
 
     def update_data(self):

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -13,13 +13,19 @@ class FdbUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
+        self.reinit_data()
+        # call our update method once to "seed" data before the "Agent" starts accepting requests.
+        self.update_data()
+
+    def reinit_data(self):
+        """
+        Subclass update interface information
+        """
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
         self.oid_name_map = mibs.init_sync_d_interface_tables()
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
 
     def update_data(self):
         """
@@ -49,7 +55,6 @@ class FdbUpdater(MIBUpdater):
             self.vlanmac_ifindex_map[vlanmac] = mibs.get_index(self.if_id_map[port_oid])
             self.vlanmac_ifindex_list.append(vlanmac)
         self.vlanmac_ifindex_list.sort()
-
 
     def fdb_ifindex(self, sub_id):
         return self.vlanmac_ifindex_map.get(sub_id, None)

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -12,7 +12,7 @@ def fdb_vlanmac(fdb):
 class FdbUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
-        self.db_conn = mibs.init_counters_db()
+        self.db_conn = mibs.init_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -25,7 +25,7 @@ class FdbUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = mibs.init_sync_d_interface_tables()
+        self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -12,7 +12,7 @@ def fdb_vlanmac(fdb):
 class FdbUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
-        self.db_conn, \
+        self.db_conn = mibs.init_counters_db()
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \


### PR DESCRIPTION
1. Refactor database connections utility
2. Add reinit_data method into mib.py. This optional method is run every minute

Previously interface list was initialized just when snmpagent starts. Now it would be reinitialized every 60 seconds.