### PR TITLE
Fix: temporarily fix DBConnector keys return none instead of empty list

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -25,6 +25,8 @@ class RouteUpdater(MIBUpdater):
 
         self.db_conn.connect(mibs.APPL_DB)
         route_entries = self.db_conn.keys(mibs.APPL_DB, "ROUTE_TABLE:*")
+        if not route_entries:
+            return
 
         for route_entry in route_entries:
             routestr = route_entry.decode()

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -33,11 +33,13 @@ class FdbUpdater(MIBUpdater):
         Pulls the table references for each interface.
         """
         self.db_conn.connect(mibs.ASIC_DB)
-        fdb_strings = self.db_conn.keys(mibs.ASIC_DB, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
         self.vlanmac_ifindex_map = {}
         self.vlanmac_ifindex_list = []
-        if fdb_strings is None:
+
+        fdb_strings = self.db_conn.keys(mibs.ASIC_DB, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
+        if not fdb_strings:
             return
+
         for s in fdb_strings:
             fdb_str = s.decode()
             try:

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -23,6 +23,10 @@ class TestForwardMIB(TestCase):
     def setUpClass(cls):
         cls.lut = MIBTable(SonicMIB)
 
+    def test_update(self):
+        for updater in TestForwardMIB.lut.updater_instances:
+            updater.update_data()
+
     def test_network_order(self):
         ip = ipaddress.ip_address("0.1.2.3")
         ipb = ip.packed


### PR DESCRIPTION
TODO: The final fix should be inside the library, let it returns empty list when there is no keys matching the pattern