### PR TITLE
Exclude non front panel interfaces from nexthop

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -40,7 +40,7 @@ class RouteUpdater(MIBUpdater):
                     ## Ignore non front panel interfaces
                     ## TODO: non front panel interfaces should not be in APPL_DB at very beginning
                     ## This is to workaround the bug in current sonic-swss implementation
-                    if ifn == "eth0" || ifn == "lo" || ifn == "docker0": continue
+                    if ifn == "eth0" or ifn == "lo" or ifn == "docker0": continue
                     sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
                     self.route_dest_list.append(sub_id)
                     self.route_dest_map[sub_id] = ipn.network_address.packed

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -35,7 +35,10 @@ class RouteUpdater(MIBUpdater):
                 ipn = ipaddress.ip_network(ipnstr)
                 ent = self.db_conn.get_all(mibs.APPL_DB, routestr, blocking=True)
                 nexthops = ent[b"nexthop"].decode()
-                for nh in nexthops.split(','):
+                ifnames = ent[b"ifname"].decode()
+                for nh, ifn in zip(nexthops.split(','), ifnames.split(',')):
+                    ## Ignore non front panel interfaces
+                    if not ifn.startswith('Ethernet'): continue
                     sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
                     self.route_dest_list.append(sub_id)
                     self.route_dest_map[sub_id] = ipn.network_address.packed

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -38,7 +38,9 @@ class RouteUpdater(MIBUpdater):
                 ifnames = ent[b"ifname"].decode()
                 for nh, ifn in zip(nexthops.split(','), ifnames.split(',')):
                     ## Ignore non front panel interfaces
-                    if not ifn.startswith('Ethernet'): continue
+                    ## TODO: non front panel interfaces should not be in APPL_DB at very beginning
+                    ## This is to workaround the bug in current sonic-swss implementation
+                    if ifn == "eth0" || ifn == "lo" || ifn == "docker0": continue
                     sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
                     self.route_dest_list.append(sub_id)
                     self.route_dest_map[sub_id] = ipn.network_address.packed


### PR DESCRIPTION
Following https://github.com/Azure/sonic-snmpagent/pull/29, fix a syntax bug.