### PR TITLE
Fix empty lag members, fix if_name_lag_name_map

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -172,6 +172,7 @@ def init_sync_d_lag_tables(db_conn):
     for lag_entry in lag_entries:
         lag_name = lag_entry[len(b"LAG_TABLE:"):]
         lag_members = db_conn.keys(APPL_DB, b"LAG_MEMBER_TABLE:%s:*" % lag_name)
+        # TODO: db_conn.keys() should really return [] instead of None
         if lag_members is None:
             lag_members = []
 

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -172,13 +172,16 @@ def init_sync_d_lag_tables(db_conn):
     for lag_entry in lag_entries:
         lag_name = lag_entry[len(b"LAG_TABLE:"):]
         lag_members = db_conn.keys(APPL_DB, b"LAG_MEMBER_TABLE:%s:*" % lag_name)
+        if lag_members is None:
+            lag_members = []
 
         def member_name_str(val, lag_name):
             return val[len(b"LAG_MEMBER_TABLE:%s:" % lag_name):]
 
-        lag_name_if_name_map[lag_name] = [member_name_str(m, lag_name) for m in lag_members]
-        for key, val in lag_name_if_name_map.items():
-            if_name_lag_name_map[key] = val
+        lag_member_names = [member_name_str(m, lag_name) for m in lag_members]
+        lag_name_if_name_map[lag_name] = lag_member_names
+        for lag_member_name in lag_member_names:
+            if_name_lag_name_map[lag_member_name] = lag_name
 
     for if_name in lag_name_if_name_map.keys():
         idx = get_index(if_name)

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -332,5 +332,42 @@
   "ROUTE_TABLE:0.0.0.0/0": {
     "ifname": "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52",
     "nexthop": "10.0.0.1,10.0.0.3,10.0.0.5,10.0.0.7,10.0.0.9,10.0.0.11,10.0.0.13,10.0.0.15,10.0.0.17,10.0.0.19,10.0.0.21,10.0.0.23,10.0.0.25,10.0.0.27"
+  },
+  "LAG_MEMBER_TABLE:PortChannel01:Ethernet112": {
+   "status": "enabled"
+  },
+  "LAG_MEMBER_TABLE:PortChannel02:Ethernet116": {
+   "status": "enabled"
+  },
+  "LAG_MEMBER_TABLE:PortChannel03:Ethernet120": {
+   "status": "enabled"
+  },
+  "LAG_MEMBER_TABLE:PortChannel04:Ethernet124": {
+    "status": "enabled"
+  },
+  "LAG_TABLE:PortChannel01": {
+    "admin_status": "up",
+    "oper_status": "up",
+    "mtu": "9216"
+  },
+  "LAG_TABLE:PortChannel02": {
+    "admin_status": "up",
+    "oper_status": "up",
+    "mtu": "9216"
+  },
+  "LAG_TABLE:PortChannel03": {
+    "admin_status": "up",
+    "oper_status": "up",
+    "mtu": "9216"
+  },
+  "LAG_TABLE:PortChannel04": {
+    "admin_status": "up",
+    "oper_status": "up",
+    "mtu": "9216"
+  },
+  "LAG_TABLE:PortChannel_Temp": {
+    "admin_status": "up",
+    "oper_status": "up",
+    "mtu": "9216"
   }
 }

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from unittest import TestCase
+
+import tests.mock_tables.dbconnector
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl import mibs
+
+class TestGetNextPDU(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def test_init_sync_d_lag_tables(self):
+        db_conn = mibs.init_db()
+
+        lag_name_if_name_map, \
+        if_name_lag_name_map, \
+        oid_lag_name_map = mibs.init_sync_d_lag_tables(db_conn)
+
+        self.assertTrue(b"PortChannel04" in lag_name_if_name_map)
+        self.assertTrue(lag_name_if_name_map[b"PortChannel04"] == [b"Ethernet124"])
+        self.assertTrue(b"Ethernet124" in if_name_lag_name_map)
+        self.assertTrue(if_name_lag_name_map[b"Ethernet124"] == b"PortChannel04")
+
+        self.assertTrue(b"PortChannel_Temp" in lag_name_if_name_map)
+        self.assertTrue(lag_name_if_name_map[b"PortChannel_Temp"] == [])


### PR DESCRIPTION
1. Fix init_sync_d_lag_tables(): supports empty LAG member
2. Fix init_sync_d_lag_tables(): if_name_lag_name_map behaves as comments
3. Add test case for LAG interfaces
