### PR TITLE
[ieee802_1ab]: This message is not needed as the device could be isolated

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -63,7 +63,6 @@ class LLDPUpdater(MIBUpdater):
         """
         Subclass update data routine. Updates available LLDP counters.
         """
-
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
 
@@ -75,8 +74,6 @@ class LLDPUpdater(MIBUpdater):
                 continue
             self.if_range.append((if_oid, ))
             self.lldp_counters.update({if_name: lldp_kvs})
-        if not self.lldp_counters:
-            logger.warning("0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.")
         self.if_range.sort()
 
     def local_port_id(self, sub_id):


### PR DESCRIPTION
```
Nov 29 00:05:31.275681 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:05:38.297445 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:05:43.314568 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:05:46.330162 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:05:50.346836 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:05:56.367286 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:06:01.406066 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:06:08.429772 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:06:12.450451 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
Nov 29 00:06:19.475502 str-s6100-acs-2 WARNING snmp-subagent [sonic_ax_impl] WARNING: 0 - b'LLDP_ENTRY_TABLE' is empty. No LLDP information could be retrieved.
```

these messages are not needed when the device is isolated.