### PR TITLE
Make MIBUpdater classes ctor no throw

### DIFF
--- a/src/ax_interface/__init__.py
+++ b/src/ax_interface/__init__.py
@@ -10,4 +10,4 @@ logger.addHandler(logging.NullHandler())
 from . import exceptions
 from .agent import Agent
 from .constants import ValueType
-from .mib import MIBMeta, MIBUpdater, MIBEntry, ContextualMIBEntry, SubtreeMIBEntry
+from .mib import MIBMeta, MIBUpdater, MIBEntry, SubtreeMIBEntry

--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -28,8 +28,8 @@ class MIBUpdater:
     def __init__(self):
         self.run_event = asyncio.Event()
         self.frequency = DEFAULT_UPDATE_FREQUENCY
-        self.update_counter = 0
         self.reinit_rate = DEFAULT_REINIT_RATE // DEFAULT_UPDATE_FREQUENCY
+        self.update_counter = self.reinit_rate + 1 # reinit_data when init
 
     async def start(self):
         # Run the update while we are allowed
@@ -314,8 +314,9 @@ class MIBTable(dict):
             # is less than our end value--it's a match.
             oid_key = remaining_oids[0]
             mib_entry = self[oid_key]
-            key1 = next(iter(mib_entry)) # get the first sub_id from the mib_etnry
-            if key1 is None:
+            try:
+                key1 = next(iter(mib_entry)) # get the first sub_id from the mib_etnry
+            except StopIteration:
                 # handler returned None, which implies there's no data, keep walking.
                 remaining_oids = remaining_oids[1:]
                 continue

--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -94,15 +94,6 @@ class MIBMeta(type):
                 sub_ids.update({_prefix + me.subtree: me})
                 prefixes.append(_prefix + me.subtree)
 
-            # gather all contextual IDs for each MIB entry--and drop them into the sub-ID listing
-            contextual_entries = (v for v in vars(cls).values() if type(v) is ContextualMIBEntry)
-            for cme in contextual_entries:
-                sub_ids.update({_prefix + cme.subtree: cme})
-                prefixes.append(_prefix + cme.subtree)
-                for sub_id in cme:
-                    sub_ids.update({_prefix + cme.subtree + sub_id: cme})
-
-
             # gather all subtree IDs
             # to support dynamic sub_id in the subtree, not to pour leaves into dictionary
             subtree_entries = (v for v in vars(cls).values() if type(v) is SubtreeMIBEntry)
@@ -181,27 +172,6 @@ class MIBEntry:
 
     def get_next(self, sub_id):
         return None
-
-class ContextualMIBEntry(MIBEntry):
-    def __init__(self, subtree, sub_ids, value_type, callable_, *args, updater=None):
-        super().__init__(subtree, value_type, callable_, *args)
-        self.sub_ids = sorted(list(sub_ids))
-        self.sub_ids = [(i,) for i in self.sub_ids]
-
-    def __iter__(self):
-        for sub_id in self.sub_ids:
-            yield sub_id
-
-    def __call__(self, sub_id):
-        if sub_id not in self.sub_ids:
-            return None
-        return self._callable_.__call__(sub_id[0], *self._callable_args)
-
-    def get_next(self, sub_id):
-        right = bisect.bisect_right(self.sub_ids, sub_id)
-        if right == len(self.sub_ids):
-            return None
-        return self.sub_ids[right]
 
 class SubtreeMIBEntry(MIBEntry):
     def __init__(self, subtree, iterator, value_type, callable_, *args, updater=None):

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -31,13 +31,16 @@ class LLDPUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
-        self.reinit_data()
+        self.if_name_map = {}
+        self.if_alias_map = {}
+        self.if_id_map = {}
+        self.oid_sai_map = {}
+        self.oid_name_map = {}
+        self.if_range = []
 
         # cache of interface counters
         # { sai_id -> { 'counter': 'value' } }
         self.lldp_counters = {}
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
 
     def reinit_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -50,8 +50,8 @@ class ArpUpdater(MIBUpdater):
         super().__init__()
         self.arp_dest_map = {}
         self.arp_dest_list = []
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
+        self.arp_dest_map = {}
+        self.arp_dest_list = []
 
     def update_data(self):
         self.arp_dest_map = {}
@@ -89,7 +89,8 @@ class NextHopUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
-        self.update_data()
+        self.nexthop_map = {}
+        self.route_list = []
 
     def update_data(self):
         """
@@ -144,7 +145,6 @@ class InterfacesUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
-        self.reinit_data()
 
         self.lag_name_if_name_map = {}
         self.if_name_lag_name_map = {}
@@ -153,8 +153,11 @@ class InterfacesUpdater(MIBUpdater):
         # cache of interface counters
         self.if_counters = {}
         self.if_range = []
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
+        self.if_name_map = {}
+        self.if_alias_map = {}
+        self.if_id_map = {}
+        self.oid_sai_map = {}
+        self.oid_name_map = {}
 
     def reinit_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -49,7 +49,6 @@ class InterfaceMIBUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
-        self.reinit_data()
 
         self.lag_name_if_name_map = {}
         self.if_name_lag_name_map = {}
@@ -57,7 +56,14 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         self.if_counters = {}
         self.if_range = []
-        self.update_data()
+        self.if_name_map = {}
+        self.if_alias_map = {}
+        self.if_id_map = {}
+        self.oid_sai_map = {}
+        self.oid_name_map = {}
+        self.lag_name_if_name_map = {}
+        self.if_name_lag_name_map = {}
+        self.oid_lag_name_map = {}
 
     def reinit_data(self):
         """
@@ -69,6 +75,13 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.oid_sai_map, \
         self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
+        self.lag_name_if_name_map, \
+        self.if_name_lag_name_map, \
+        self.oid_lag_name_map = mibs.init_sync_d_lag_tables(self.db_conn)
+
+        self.if_range = sorted(list(self.oid_sai_map.keys()) + list(self.oid_lag_name_map.keys()))
+        self.if_range = [(i,) for i in self.if_range]
+
     def update_data(self):
         """
         Update redis (caches config)
@@ -78,12 +91,6 @@ class InterfaceMIBUpdater(MIBUpdater):
             sai_id: self.db_conn.get_all(mibs.COUNTERS_DB, mibs.counter_table(sai_id), blocking=True)
             for sai_id in self.if_id_map}
 
-        self.lag_name_if_name_map, \
-        self.if_name_lag_name_map, \
-        self.oid_lag_name_map = mibs.init_sync_d_lag_tables(self.db_conn)
-
-        self.if_range = sorted(list(self.oid_sai_map.keys()) + list(self.oid_lag_name_map.keys()))
-        self.if_range = [(i,) for i in self.if_range]
 
     def get_next(self, sub_id):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -3,7 +3,7 @@ import ipaddress
 from enum import unique, Enum
 
 from sonic_ax_impl import mibs
-from ax_interface import MIBMeta, ValueType, MIBUpdater, ContextualMIBEntry, SubtreeMIBEntry
+from ax_interface import MIBMeta, ValueType, MIBUpdater, SubtreeMIBEntry
 from ax_interface.encodings import OctetString
 from ax_interface.util import mac_decimals, ip2tuple_v4
 from bisect import bisect_right

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -13,7 +13,8 @@ class RouteUpdater(MIBUpdater):
         super().__init__()
         self.tos = 0 # ipCidrRouteTos
         self.db_conn = mibs.init_db()
-        self.update_data()
+        self.route_dest_map = {}
+        self.route_dest_list = []
 
     def update_data(self):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -3,7 +3,7 @@ from enum import unique, Enum
 
 from sonic_ax_impl import mibs
 from swsssdk import port_util
-from ax_interface import MIBMeta, ValueType, MIBUpdater, ContextualMIBEntry, SubtreeMIBEntry
+from ax_interface import MIBMeta, ValueType, MIBUpdater, SubtreeMIBEntry
 from ax_interface.util import mac_decimals
 from bisect import bisect_right
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -16,9 +16,14 @@ class FdbUpdater(MIBUpdater):
         self.db_conn = mibs.init_db()
 
         self.prev_if_id_map = {}
-        self.reinit_data()
-        # call our update method once to "seed" data before the "Agent" starts accepting requests.
-        self.update_data()
+        self.if_name_map = {}
+        self.if_alias_map = {}
+        self.if_id_map = {}
+        self.oid_sai_map = {}
+        self.oid_name_map = {}
+        self.vlanmac_ifindex_map = {}
+        self.vlanmac_ifindex_list = []
+        self.if_bpid_map = {}
 
     def reinit_data(self):
         """

--- a/tests/test_arp.py
+++ b/tests/test_arp.py
@@ -23,6 +23,17 @@ class TestSonicMIB(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.lut = MIBTable(SonicMIB)
+        for updater in cls.lut.updater_instances:
+            updater.update_data()
+            updater.reinit_data()
+            updater.update_data()
+
+    # TODO: this test fails, possible reason maybe mock arptable
+    # def test_update(self):
+        # for updater in self.lut.updater_instances:
+            # updater.update_data()
+            # updater.reinit_data()
+            # updater.update_data()
 
     def test_getpdu(self):
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 3, 6, 1, 2, 1, 4, 22, 1, 2, 37, 10, 0, 0, 19))

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -24,7 +24,9 @@ class TestForwardMIB(TestCase):
         cls.lut = MIBTable(SonicMIB)
 
     def test_update(self):
-        for updater in TestForwardMIB.lut.updater_instances:
+        for updater in self.lut.updater_instances:
+            updater.update_data()
+            updater.reinit_data()
             updater.update_data()
 
     def test_network_order(self):

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -24,6 +24,12 @@ class TestGetNextPDU(TestCase):
     def setUpClass(cls):
         cls.lut = MIBTable(rfc2863.InterfaceMIBObjects)
 
+    def test_update(self):
+        for updater in self.lut.updater_instances:
+            updater.update_data()
+            updater.reinit_data()
+            updater.update_data()
+
     def test_getnextpdu_firstifalias(self):
         # oid.include = 1
         oid = ObjectIdentifier(10, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18))


### PR DESCRIPTION
Originally some updaters wait for COUNTERS_PORT_NAME_MAP and/or other critical data structures in redis in ctor. If syncd does things slowly, the waiting will timeout, and crash the subagent process.

This pull request make the updater ctor quite safe, ie. no throw at all. And any future updating exceptions are already handled well by the class MIBTable.

Tested rebooting in lab, with a small wait timeout.
