### PR TITLE
Fix/enhance lldp MIBs., add MockPubSub to mock_tables.dbconnector.py

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -27,6 +27,7 @@ class LLDPRemoteTables(int, Enum):
     lldp_rem_sys_cap_supported = 11
     lldp_rem_sys_cap_enabled = 12
 
+
 @unique
 class LLDPLocalChassis(int, Enum):
     """
@@ -117,11 +118,12 @@ class LocPortUpdater(MIBUpdater):
                 break
 
             lldp_entry = msg["channel"].split(b":")[-1].decode()
-            data = msg['data'] # event data
+            data = msg['data']  # event data
 
             # extract interface name
             interface = lldp_entry.split('|')[-1]
-            #ignore management interface
+
+            # ignore management interface
             if interface == "eth0":
                 continue
             # get interface from interface name
@@ -488,4 +490,3 @@ class LLDPRemTable(metaclass=MIBMeta, prefix='.1.0.8802.1.1.2.1.4.1'):
     lldpRemSysCapEnabled = \
         SubtreeMIBEntry('1.12', lldp_updater, ValueType.OCTET_STRING, lldp_updater.lldp_table_lookup,
                         LLDPRemoteTables(12))
-

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -46,6 +46,7 @@ class LocPortUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
+        self.db_conn.connect(mibs.APPL_DB)
         self.if_name_map = {}
         self.if_alias_map = {}
         self.if_id_map = {}

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -2,7 +2,6 @@
 import json
 import os
 
-import unittest.mock
 import mockredis
 import swsssdk.interface
 from swsssdk.interface import redis
@@ -28,6 +27,7 @@ class MockPubSub:
 
 
 INPUT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 class SwssSyncClient(mockredis.MockRedis):
     def __init__(self, *args, **kwargs):

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -2,6 +2,7 @@
 import json
 import os
 
+import unittest.mock
 import mockredis
 import swsssdk.interface
 from swsssdk.interface import redis
@@ -13,6 +14,17 @@ def _subscribe_keyspace_notification(self, db_name, client):
 
 def config_set(self, *args):
     pass
+
+
+class MockPubSub:
+    def get_message(self):
+        return None
+
+    def psubscribe(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
 
 
 INPUT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -31,6 +43,7 @@ class SwssSyncClient(mockredis.MockRedis):
             fname = 'state_db.json'
         else:
             raise ValueError("Invalid db")
+        self.pubsub = MockPubSub()
 
         fname = os.path.join(INPUT_DIR, fname)
         with open(fname) as f:


### PR DESCRIPTION
Add mock pubsub, so unittests can properly test MIBs with updaters that use keyspace notifications.
Also fix/enhance lldp MIBs.