### PR TITLE
[lldp] LLDP-MIB indexes according to specification

### DIFF
--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -176,3 +176,18 @@ class TestLLDPMIB(TestCase):
         pdu = PDU.decode(break2)
         resp = pdu.make_response(self.lut)
         print(resp)
+
+    def test_getnextpdu_noeth(self):
+        # oid.include = 1
+        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 18545, 126, 1))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        print("GetNextPDU sr=", get_pdu.sr)
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.END_OF_MIB_VIEW)

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -33,7 +33,7 @@ class TestLLDPMIB(TestCase):
             updater.update_data()
 
     def test_getnextpdu_eth1(self):
-        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1))
+        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1, 1))
         get_pdu = GetNextPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
@@ -46,12 +46,12 @@ class TestLLDPMIB(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         print("test_getnextpdu_exactmatch: ", str(oid))
-        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1))))
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1, 1))))
         self.assertEqual(str(value0.data), "Ethernet1")
 
     def test_getnextpdu_eth2(self):
         # oid.include = 1
-        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 5))
+        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1, 5))
         get_pdu = GetNextPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
@@ -64,13 +64,13 @@ class TestLLDPMIB(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         print("test_getnextpdu_exactmatch: ", str(oid))
-        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 5))))
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 1, 5))))
         self.assertEqual(str(value0.data), "Ethernet2")
 
     def test_subtype_lldp_rem_table(self):
         for entry in range(2, 13):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, entry)]
-            ret = mib_entry(sub_id=(1,))
+            ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
             print(ret)
 
@@ -98,7 +98,7 @@ class TestLLDPMIB(TestCase):
     def test_subtype_lldp_rem_man_addr_table(self):
         for entry in range(1, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1,))
+            ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
             print(ret)
 
@@ -106,12 +106,12 @@ class TestLLDPMIB(TestCase):
         # ethernet0 has IPv4 remote management address
         interface_number = 1
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 2)]
-        ret = mib_entry(sub_id=(interface_number,))
+        ret = mib_entry(sub_id=(1, interface_number,))
         self.assertEquals(ret, "0A E0 19 64")
         print(ret)
         # test remManAddrSubtype
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 1)]
-        ret = mib_entry(sub_id=(interface_number,))
+        ret = mib_entry(sub_id=(1, interface_number,))
         # subtype 1 means IPv4
         self.assertEquals(ret, 1)
         print(ret)
@@ -120,12 +120,12 @@ class TestLLDPMIB(TestCase):
         # ethernet4 has IPv6 remote management address
         interface_number = 5
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 2)]
-        ret = mib_entry(sub_id=(interface_number,))
+        ret = mib_entry(sub_id=(1, interface_number,))
         self.assertEquals(ret, "fe80 0 268a 7ff fe3f 834c")
         print(ret)
         # test remManAddrSubtype
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 1)]
-        ret = mib_entry(sub_id=(interface_number,))
+        ret = mib_entry(sub_id=(1, interface_number,))
         # subtype 2 means IPv6
         self.assertEquals(ret, 2)
         print(ret)
@@ -139,7 +139,7 @@ class TestLLDPMIB(TestCase):
     def test_local_port_num(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 2)]
         for num in range(1, 126, 4):
-            ret = mib_entry(sub_id=(num,))
+            ret = mib_entry(sub_id=(1, num,))
             self.assertEqual(ret, num)
 
     def test_getnextpdu_local_port_identification(self):
@@ -176,20 +176,3 @@ class TestLLDPMIB(TestCase):
         pdu = PDU.decode(break2)
         resp = pdu.make_response(self.lut)
         print(resp)
-
-
-    def test_getnextpdu_noeth(self):
-        # oid.include = 1
-        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 7, 126))
-        get_pdu = GetNextPDU(
-            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
-            oids=[oid]
-        )
-
-        print("GetNextPDU sr=", get_pdu.sr)
-        encoded = get_pdu.encode()
-        response = get_pdu.make_response(self.lut)
-        print(response)
-        value0 = response.values[0]
-        self.assertEqual(value0.type_, ValueType.END_OF_MIB_VIEW)
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 I noticed that for some LLDP MIB tables the indexes are not correct according to specification.
For example lets consider lldpRemTable:
```
lldpRemEntry OBJECT-TYPE
    SYNTAX      LldpRemEntry
 . . .
    INDEX   {
           lldpRemTimeMark,
           lldpRemLocalPortNum,
           lldpRemIndex
    }
    ::= { lldpRemTable 1 }
```
This means that we have some meaningful sub oids when doing snmpwalk:
```
 snmpwalk  -v1  -cpublic arc-switch1041  1.0.8802.1.1.2.1.4.1
iso.0.8802.1.1.2.1.4.1.1.1.61552.85.25 = Timeticks: (61552) 0:10:15.52
. . . 
```
iso.0.8802.1.1.2.1.4.1 - lldpRemTable
.1 -  lldpRemEntry
.1 - lldpRemTimeMark
.61552 - lldpRemTimeMark (index )
.85 - lldpRemLocalPortNum (index )
.25 - lldpRemIndex (index)

Example snmpwalk output:
Previously we had:
```
snmpwalk  -v2c  -cpublic arc-switch1038  1.0.8802.1.1.2.1.4.1.1.1
iso.0.8802.1.1.2.1.4.1.1.1.113 = Timeticks: (2460) 0:00:24.60
iso.0.8802.1.1.2.1.4.1.1.1.117 = Timeticks: (8340) 0:01:23.40
iso.0.8802.1.1.2.1.4.1.1.1.121 = Timeticks: (8337) 0:01:23.37
iso.0.8802.1.1.2.1.4.1.1.1.125 = Timeticks: (8336) 0:01:23.36
```
Notice the only index is local port number (113, 117, 121, 125)

After the changes:
```
snmpwalk  -v2c  -cpublic arc-switch1038  1.0.8802.1.1.2.1.4.1.1.1
iso.0.8802.1.1.2.1.4.1.1.1.2460.113.2 = Timeticks: (2460) 0:00:24.60
iso.0.8802.1.1.2.1.4.1.1.1.8340.117.3 = Timeticks: (8340) 0:01:23.40
iso.0.8802.1.1.2.1.4.1.1.1.8337.121.4 = Timeticks: (8337) 0:01:23.37
iso.0.8802.1.1.2.1.4.1.1.1.8336.125.5 = Timeticks: (8336) 0:01:23.36
```
Take note that each entry now has 3 indexes: 
 - lldpRemTimeMark,
 - lldpRemLocalPortNum,
 - lldpRemIndex 

**- How I did it**
Changed the MIB code, updated unittests.
**- How to verify it**
Run snmpwalk
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Implement LLDP-MIB indexes according to specification
