### PR TITLE
Remove alias_map.json

### DIFF
--- a/src/sonic_ax_impl/__init__.py
+++ b/src/sonic_ax_impl/__init__.py
@@ -1,25 +1,9 @@
 import json
 import logging.handlers
 
-# path where a user may define an alias map
-USER_DEFINED_ALIAS_MAP_FILEPATH = '/etc/snmp/alias_map.json'
 
 # configure logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.NullHandler())
 
-_if_alias_map = None
-
-# open user-defined alias map first
-try:
-    with open(USER_DEFINED_ALIAS_MAP_FILEPATH) as f:
-        _if_alias_map = json.load(f)
-        _if_alias_map = {k.encode('ascii'): v.encode('ascii') for k, v in _if_alias_map.items()}
-except ValueError as e:
-    logger.error(
-        "User map contains error(s). Ensure file is well-formed JSON. Falling back to default map. {}".format(str(e))
-    )
-except OSError:
-    # No alias map found, error is emitted and handled in mibs/__init__.py
-    logger.info("No user-defined alias map found, using default map.")

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -456,254 +456,160 @@
   },
   "PORT_TABLE:Ethernet0": {
     "description": "snowflake",
+    "alias": "etp1",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet4": {
     "description": "snowflake",
+    "alias": "etp2",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet8": {
     "description": "snowflake",
+    "alias": "etp3",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet12": {
     "description": "snowflake",
+    "alias": "etp4",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet16": {
     "description": "snowflake",
+    "alias": "etp5",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet20": {
     "description": "snowflake",
+    "alias": "etp6",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet24": {
     "description": "snowflake",
+    "alias": "etp7",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet28": {
     "description": "snowflake",
+    "alias": "etp8",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet32": {
     "description": "snowflake",
+    "alias": "etp9",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet36": {
     "description": "snowflake",
+    "alias": "etp10",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet40": {
     "description": "snowflake",
+    "alias": "etp11",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet44": {
     "description": "snowflake",
+    "alias": "etp12",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet48": {
     "description": "snowflake",
+    "alias": "etp13",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet52": {
     "description": "snowflake",
+    "alias": "etp14",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet56": {
     "description": "snowflake",
+    "alias": "etp15",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet60": {
     "description": "snowflake",
+    "alias": "etp16",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet64": {
     "description": "snowflake",
+    "alias": "etp17",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet68": {
     "description": "snowflake",
+    "alias": "etp18",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet72": {
     "description": "snowflake",
+    "alias": "etp19",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet76": {
     "description": "snowflake",
+    "alias": "etp20",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet80": {
     "description": "snowflake",
+    "alias": "etp21",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet84": {
     "description": "snowflake",
+    "alias": "etp22",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet88": {
     "description": "snowflake",
+    "alias": "etp23",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet92": {
     "description": "snowflake",
+    "alias": "etp24",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet96": {
     "description": "snowflake",
+    "alias": "etp25",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet100": {
     "description": "snowflake",
+    "alias": "etp26",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet104": {
     "description": "snowflake",
+    "alias": "etp27",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet108": {
     "description": "snowflake",
+    "alias": "etp28",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet112": {
     "description": "snowflake",
+    "alias": "etp29",
     "speed": 100000
   },
   "PORT_TABLE:Ethernet116": {
-    "speed": 1000
+    "speed": 1000,
+    "alias": "etp30"
   },
   "PORT_TABLE:Ethernet120": {
-    "description": "snowflake"
+    "description": "snowflake",
+    "alias": "et31"
   },
   "PORT_TABLE:Ethernet124": {
     "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet0": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet4": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet8": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet12": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet16": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet20": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet24": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet28": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet32": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet36": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet40": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet44": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet48": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet52": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet56": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet60": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet64": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet68": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet72": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet76": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet80": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet84": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet88": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet92": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet96": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet100": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet104": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet108": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet112": {
-    "description": "snowflake",
-    "speed": 100000
-  },
-  "PORT_TABLE:Ethernet116": {
-    "speed": 1000
-  },
-  "PORT_TABLE:Ethernet120": {
-    "description": "snowflake"
-  },
-  "PORT_TABLE:Ethernet124": {
-    "description": "snowflake",
+    "alias": "etp32",
     "speed": 100000
   },
   "ROUTE_TABLE:0.0.0.0/0": {

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -133,7 +133,7 @@ class TestLLDPMIB(TestCase):
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(1,))
-        self.assertEquals(ret, b'Ethernet0')
+        self.assertEquals(ret, b'etp1')
         print(ret)
 
     def test_local_port_num(self):
@@ -154,7 +154,7 @@ class TestLLDPMIB(TestCase):
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
-        self.assertEqual(str(value0.data), "Ethernet0")
+        self.assertEqual(str(value0.data), "etp1")
 
     def test_lab_breaks(self):
         break1 = b'\x01\x06\x10\x00\x00\x00\x00q\x00\x01\xd1\x02\x00\x01\xd1\x03\x00\x00\x00P\t\x00\x01\x00\x00' \

--- a/tests/test_sn.py
+++ b/tests/test_sn.py
@@ -66,7 +66,7 @@ class TestSonicMIB(TestCase):
         sub_id = 1000 * 1 # sub id for Ethernet100
 
         expected_mib = {
-            2: (ValueType.OCTET_STRING, "QSFP+ for Ethernet0"),
+            2: (ValueType.OCTET_STRING, "QSFP+ for etp1"),
             5: (ValueType.INTEGER, PhysicalClass.PORT),
             7: (ValueType.OCTET_STRING, ""), # skip
             8: (ValueType.OCTET_STRING, "A1"),
@@ -97,20 +97,20 @@ class TestSonicMIB(TestCase):
 
     def test_getpdu_xcvr_dom(self):
         expected_mib = {
-            1000 * 1 + 1: "DOM Temperature Sensor for Ethernet0",
-            1000 * 1 + 2: "DOM Voltage Sensor for Ethernet0",
-            1000 * 1 + 11: "DOM RX Power Sensor for Ethernet0/1",
-            1000 * 1 + 21: "DOM RX Power Sensor for Ethernet0/2",
-            1000 * 1 + 31: "DOM RX Power Sensor for Ethernet0/3",
-            1000 * 1 + 41: "DOM RX Power Sensor for Ethernet0/4",
-            1000 * 1 + 12: "DOM TX Bias Sensor for Ethernet0/1",
-            1000 * 1 + 22: "DOM TX Bias Sensor for Ethernet0/2",
-            1000 * 1 + 32: "DOM TX Bias Sensor for Ethernet0/3",
-            1000 * 1 + 42: "DOM TX Bias Sensor for Ethernet0/4",
-            1000 * 1 + 13: "DOM TX Power Sensor for Ethernet0/1",
-            1000 * 1 + 23: "DOM TX Power Sensor for Ethernet0/2",
-            1000 * 1 + 33: "DOM TX Power Sensor for Ethernet0/3",
-            1000 * 1 + 43: "DOM TX Power Sensor for Ethernet0/4",
+            1000 * 1 + 1: "DOM Temperature Sensor for etp1",
+            1000 * 1 + 2: "DOM Voltage Sensor for etp1",
+            1000 * 1 + 11: "DOM RX Power Sensor for etp1/1",
+            1000 * 1 + 21: "DOM RX Power Sensor for etp1/2",
+            1000 * 1 + 31: "DOM RX Power Sensor for etp1/3",
+            1000 * 1 + 41: "DOM RX Power Sensor for etp1/4",
+            1000 * 1 + 12: "DOM TX Bias Sensor for etp1/1",
+            1000 * 1 + 22: "DOM TX Bias Sensor for etp1/2",
+            1000 * 1 + 32: "DOM TX Bias Sensor for etp1/3",
+            1000 * 1 + 42: "DOM TX Bias Sensor for etp1/4",
+            1000 * 1 + 13: "DOM TX Power Sensor for etp1/1",
+            1000 * 1 + 23: "DOM TX Power Sensor for etp1/2",
+            1000 * 1 + 33: "DOM TX Power Sensor for etp1/3",
+            1000 * 1 + 43: "DOM TX Power Sensor for etp1/4",
         }
 
         phyDescr, phyClass = 2, 5


### PR DESCRIPTION
This file was added long time ago and now it is not needed anymore.
We can simply get port aliases from DB.

This also means that aliases will be now updated from DB once
a reinit timeout, instead of beeing static in alias_map.json

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I removed alias_map.json from SNMP agent. That map is not needed anymore since we can get port alias directly from DB

**- How I did it**
1. Removed /etc/snmp/alias_map.json parsing
2. Generate ```if_alias_map``` using aliases from APPL_DB
3. Added aliases in test appl_db.json table and fixed tests, that were expecting that alias == ifname

**- How to verify it**
Run unittests, run snmp agent on DUT and verify that we can still see correct aliases in SNMP MIBs

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove alias_map.json
