### PR TITLE
Add managment port support to RFC1213, RFC2863, IEEE802.1ab MIBs

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -97,6 +97,13 @@ def lag_entry_table(lag_name):
     """
     return b'LAG_TABLE:' + lag_name
 
+def mgmt_if_entry_table(if_name):
+    """
+    :param if_name: given interface to cast
+    :return: MGMT_PORT_TABLE key
+    """
+
+    return b'MGMT_PORT_TABLE:' + if_name
 
 def config(**kwargs):
     global redis_kwargs
@@ -112,6 +119,35 @@ def init_db():
     db_conn = SonicV2Connector(**redis_kwargs)
 
     return db_conn
+
+def init_mgmt_interface_tables(db_conn):
+    """
+    Initializes interface maps for mgmt ports
+    :param db_conn: db connector
+    :return: tuple of mgmt name to oid map and mgmt name to alias map
+    """
+
+    db_conn.connect(APPL_DB)
+
+    mgmt_ports_keys = db_conn.keys(APPL_DB, mgmt_if_entry_table(b'*'))
+
+    if not mgmt_ports_keys:
+        logger.warning('No managment ports found in {}'.format(mgmt_if_entry_table(b'')))
+        return {}, {}
+
+    mgmt_ports = [key.split(mgmt_if_entry_table(b''))[-1] for key in mgmt_ports_keys]
+    oid_name_map = {get_index(mgmt_name): mgmt_name for mgmt_name in mgmt_ports}
+    logger.debug('Managment port map:\n' + pprint.pformat(oid_name_map, indent=2))
+
+    if_alias_map = dict()
+
+    for if_name in oid_name_map.values():
+        if_entry = db_conn.get_all(APPL_DB, mgmt_if_entry_table(if_name), blocking=True)
+        if_alias_map[if_name] = if_entry.get(b'alias', if_name)
+
+    logger.debug("Management alias map:\n" + pprint.pformat(if_alias_map, indent=2))
+
+    return oid_name_map, if_alias_map
 
 
 def init_sync_d_interface_tables(db_conn):

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -85,9 +85,6 @@ def poll_lldp_entry_updates(pubsub):
                      "The error seems to be: {}".format(msg, e))
         return ret
 
-    if interface == 'eth0':
-        return ret
-
     # get interface from interface name
     if_index = port_util.get_index_from_str(interface)
 
@@ -147,6 +144,10 @@ class LocPortUpdater(MIBUpdater):
         self.if_id_map = {}
         self.oid_sai_map = {}
         self.oid_name_map = {}
+
+        self.mgmt_oid_name_map = {}
+        self.mgmt_alias_map = {}
+
         self.if_range = []
 
         # cache of port data
@@ -164,6 +165,13 @@ class LocPortUpdater(MIBUpdater):
         self.oid_sai_map, \
         self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
 
+        self.mgmt_oid_name_map, \
+        self.mgmt_alias_map = mibs.init_mgmt_interface_tables(self.db_conn)
+
+        # merge dataplane and mgmt ports
+        self.oid_name_map.update(self.mgmt_oid_name_map)
+        self.if_alias_map.update(self.mgmt_alias_map)
+
         self.if_range = []
         # get local port kvs from APP_BD's PORT_TABLE
         self.loc_port_data = {}
@@ -174,11 +182,22 @@ class LocPortUpdater(MIBUpdater):
         if not self.loc_port_data:
             logger.warning("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
 
+    def _get_if_entry(self, if_name):
+        if_table = ""
+
+        if if_name in self.if_name_map:
+            if_table = mibs.if_entry_table(if_name)
+        elif if_name in self.mgmt_oid_name_map.values():
+            if_table = mibs.mgmt_if_entry_table(if_name)
+
+        return self.db_conn.get_all(mibs.APPL_DB, if_table)
+
     def update_interface_data(self, if_name):
         """
         Update data from the DB for a single interface
         """
-        loc_port_kvs = self.db_conn.get_all(mibs.APPL_DB, mibs.if_entry_table(if_name))
+
+        loc_port_kvs = self._get_if_entry(if_name)
         if not loc_port_kvs:
             return
         self.loc_port_data.update({if_name: loc_port_kvs})
@@ -344,6 +363,9 @@ class LLDPRemTableUpdater(MIBUpdater):
         self.if_id_map = {}
         self.oid_sai_map = {}
         self.oid_name_map = {}
+
+        self.mgmt_oid_name_map = {}
+
         self.if_range = []
 
         # cache of interface counters
@@ -359,6 +381,10 @@ class LLDPRemTableUpdater(MIBUpdater):
         self.if_id_map, \
         self.oid_sai_map, \
         self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
+
+        self.mgmt_oid_name_map, _ = mibs.init_mgmt_interface_tables(self.db_conn)
+
+        self.oid_name_map.update(self.mgmt_oid_name_map)
 
     def get_next(self, sub_id):
         """
@@ -443,6 +469,7 @@ class LLDPRemManAddrUpdater(MIBUpdater):
         self.if_range = []
         self.mgmt_ips = {}
         self.oid_name_map = {}
+        self.mgmt_oid_name_map = {}
         self.mgmt_ip_str = None
         self.pubsub = None
 
@@ -508,6 +535,11 @@ class LLDPRemManAddrUpdater(MIBUpdater):
         Subclass reinit data routine.
         """
         _, _, _, _, self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
+
+        self.mgmt_oid_name_map, _ = mibs.init_mgmt_interface_tables(self.db_conn)
+
+        self.oid_name_map.update(self.mgmt_oid_name_map)
+
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
 

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -185,12 +185,16 @@ class LocPortUpdater(MIBUpdater):
     def _get_if_entry(self, if_name):
         if_table = ""
 
+        db = mibs.APPL_DB
         if if_name in self.if_name_map:
             if_table = mibs.if_entry_table(if_name)
         elif if_name in self.mgmt_oid_name_map.values():
             if_table = mibs.mgmt_if_entry_table(if_name)
+            db = mibs.CONFIG_DB
+        else:
+            return None
 
-        return self.db_conn.get_all(mibs.APPL_DB, if_table)
+        return self.db_conn.get_all(db, if_table, blocking=True)
 
     def update_interface_data(self, if_name):
         """

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -185,6 +185,8 @@ class LocPortUpdater(MIBUpdater):
     def _get_if_entry(self, if_name):
         if_table = ""
 
+        # Once PORT_TABLE will be moved to CONFIG DB
+        # we will get entry from CONFIG_DB for all cases
         db = mibs.APPL_DB
         if if_name in self.if_name_map:
             if_table = mibs.if_entry_table(if_name)

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -306,6 +306,8 @@ class InterfacesUpdater(MIBUpdater):
             return
 
         if_table = ""
+        # Once PORT_TABLE will be moved to CONFIG DB
+        # we will get entry from CONFIG_DB for all cases
         db = mibs.APPL_DB
         if oid in self.oid_lag_name_map:
             if_table = mibs.lag_entry_table(self.oid_lag_name_map[oid])
@@ -349,6 +351,9 @@ class InterfacesUpdater(MIBUpdater):
             b"down": 2
         }
 
+        # Once PORT_TABLE will be moved to CONFIG DB
+        # we will get rid of this if-else
+        # and read oper status from STATE_DB
         if self.get_oid(sub_id) in self.mgmt_oid_name_map and key == b"oper_status":
             entry = self._get_if_entry_state_db(sub_id)
         else:

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -206,6 +206,8 @@ class InterfaceMIBUpdater(MIBUpdater):
             return
 
         if_table = ""
+        # Once PORT_TABLE will be moved to CONFIG DB
+        # we will get entry from CONFIG_DB for all cases
         db = mibs.APPL_DB
         if oid in self.oid_lag_name_map:
             if_table = mibs.lag_entry_table(self.oid_lag_name_map[oid])

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -53,6 +53,8 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.lag_name_if_name_map = {}
         self.if_name_lag_name_map = {}
         self.oid_lag_name_map = {}
+        self.mgmt_oid_name_map = {}
+        self.mgmt_alias_map = {}
 
         self.if_counters = {}
         self.if_range = []
@@ -79,7 +81,12 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_name_lag_name_map, \
         self.oid_lag_name_map = mibs.init_sync_d_lag_tables(self.db_conn)
 
-        self.if_range = sorted(list(self.oid_sai_map.keys()) + list(self.oid_lag_name_map.keys()))
+        self.mgmt_oid_name_map, \
+        self.mgmt_alias_map = mibs.init_mgmt_interface_tables(self.db_conn)
+
+        self.if_range = sorted(list(self.oid_sai_map.keys()) +
+                               list(self.oid_lag_name_map.keys()) +
+                               list(self.mgmt_oid_name_map.keys()))
         self.if_range = [(i,) for i in self.if_range]
 
     def update_data(self):
@@ -123,6 +130,8 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         if oid in self.oid_lag_name_map:
             return self.oid_lag_name_map[oid]
+        elif oid in self.mgmt_oid_name_map:
+            return self.mgmt_alias_map[self.mgmt_oid_name_map[oid]]
 
         return self.if_alias_map[self.oid_name_map[oid]]
 
@@ -160,6 +169,13 @@ class InterfaceMIBUpdater(MIBUpdater):
         :param mask: mask to apply to counter
         :return: the counter for the respective sub_id/table.
         """
+
+        if oid in self.mgmt_oid_name_map:
+            # TODO: mgmt counters not available through SNMP right now
+            # COUNTERS DB does not have suppot for generic linux (mgmt) interface counters
+            mibs.logger.warning('management interface counters not available through SNMP right now')
+            return 0
+
         if oid in self.oid_lag_name_map:
             counter_value = 0
             for lag_member in self.lag_name_if_name_map[self.oid_lag_name_map[oid]]:
@@ -192,6 +208,8 @@ class InterfaceMIBUpdater(MIBUpdater):
         if_table = ""
         if oid in self.oid_lag_name_map:
             if_table = mibs.lag_entry_table(self.oid_lag_name_map[oid])
+        elif oid in self.mgmt_oid_name_map:
+            if_table = mibs.mgmt_if_entry_table(self.mgmt_oid_name_map[oid])
         else:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -206,14 +206,18 @@ class InterfaceMIBUpdater(MIBUpdater):
             return
 
         if_table = ""
+        db = mibs.APPL_DB
         if oid in self.oid_lag_name_map:
             if_table = mibs.lag_entry_table(self.oid_lag_name_map[oid])
         elif oid in self.mgmt_oid_name_map:
             if_table = mibs.mgmt_if_entry_table(self.mgmt_oid_name_map[oid])
-        else:
+            db = mibs.CONFIG_DB
+        elif oid in self.oid_name_map:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
+        else:
+            return None
 
-        return self.db_conn.get_all(mibs.APPL_DB, if_table, blocking=True)
+        return self.db_conn.get_all(db, if_table, blocking=True)
 
     def get_high_speed(self, sub_id):
         """

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -447,6 +447,20 @@
     "lldp_rem_port_id": "Ethernet32",
     "lldp_rem_man_addr": "10.224.25.131"
   },
+  "LLDP_ENTRY_TABLE:eth1": {
+    "lldp_rem_port_id_subtype": "5",
+    "lldp_rem_sys_cap_supported": "28 00",
+    "lldp_rem_index": "1",
+    "lldp_rem_chassis_id": "00:11:22:33:44:55",
+    "lldp_rem_sys_desc": "I'm a little teapot.",
+    "lldp_rem_time_mark": "4834",
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_port_desc": " ",
+    "lldp_rem_chassis_id_subtype": "4",
+    "lldp_rem_sys_name": "switch14",
+    "lldp_rem_port_id": "Ethernet0",
+    "lldp_rem_man_addr": "10.224.1.100"
+  },
   "LLDP_LOC_CHASSIS": {
     "lldp_loc_chassis_id_subtype": "5",
     "lldp_loc_chassis_id": "00:11:22:AB:CD:EF",
@@ -611,6 +625,15 @@
     "description": "snowflake",
     "alias": "etp32",
     "speed": 100000
+  },
+  "MGMT_PORT_TABLE:eth0": {
+    "description": "snowflake",
+    "speed": 1000
+  },
+  "MGMT_PORT_TABLE:eth1": {
+    "description": "snowflake",
+    "alias": "mgmt1",
+    "speed": 1000
   },
   "ROUTE_TABLE:0.0.0.0/0": {
     "ifname": "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52",

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -626,15 +626,6 @@
     "alias": "etp32",
     "speed": 100000
   },
-  "MGMT_PORT_TABLE:eth0": {
-    "description": "snowflake",
-    "speed": 1000
-  },
-  "MGMT_PORT_TABLE:eth1": {
-    "description": "snowflake",
-    "alias": "mgmt1",
-    "speed": 1000
-  },
   "ROUTE_TABLE:0.0.0.0/0": {
     "ifname": "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52",
     "nexthop": "10.0.0.1,10.0.0.3,10.0.0.5,10.0.0.7,10.0.0.9,10.0.0.11,10.0.0.13,10.0.0.15,10.0.0.17,10.0.0.19,10.0.0.21,10.0.0.23,10.0.0.25,10.0.0.27"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1,0 +1,11 @@
+{
+  "MGMT_PORT|eth0": {
+    "description": "snowflake",
+    "speed": 1000
+  },
+  "MGMT_PORT|eth1": {
+    "description": "snowflake",
+    "alias": "mgmt1",
+    "speed": 1000
+  }
+}

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -5,6 +5,7 @@
   },
   "MGMT_PORT|eth1": {
     "description": "snowflake",
+    "admin_status": "up",
     "alias": "mgmt1",
     "speed": 1000
   }

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -40,6 +40,8 @@ class SwssSyncClient(mockredis.MockRedis):
             fname = 'asic_db.json'
         elif db == 2:
             fname = 'counters_db.json'
+        elif db == 4:
+            fname = 'config_db.json'
         elif db == 6:
             fname = 'state_db.json'
         else:

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -24,5 +24,11 @@
   	"tx2power": -5.4,
   	"tx3power": -5.4,
   	"tx4power": -5.4
+  },
+  "MGMT_PORT_TABLE|eth0": {
+    "oper_status": "down"
+  },
+  "MGMT_PORT_TABLE|eth1": {
+    "oper_status": "up"
   }
 }

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -166,3 +166,22 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 117))))
         self.assertEqual(str(value0.data), '')
+
+    def test_mgmt_iface(self):
+        """
+        Test that mgmt port is present in the MIB
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10000))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10000))))
+        self.assertEqual(str(value0.data), 'eth0')

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -167,7 +167,7 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 117))))
         self.assertEqual(str(value0.data), '')
 
-    def test_mgmt_iface(self):
+    def test_mgmt_iface_name(self):
         """
         Test that mgmt port is present in the MIB
         """
@@ -185,3 +185,22 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10000))))
         self.assertEqual(str(value0.data), 'eth0')
+
+    def test_mgmt_iface_alias(self):
+        """
+        Test that mgmt port alias
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10001))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10001))))
+        self.assertEqual(str(value0.data), 'mgmt1')

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -247,3 +247,22 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10001))))
         self.assertEqual(value0.data, 10000)
 
+    def test_mgmt_iface_oper_status(self):
+        """
+        Test mgmt port operative status
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10001))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10001))))
+        self.assertEqual(value0.data, 1)
+

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -266,3 +266,21 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10001))))
         self.assertEqual(value0.data, 1)
 
+    def test_mgmt_iface_admin_status(self):
+        """
+        Test mgmt port admin status
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 10001))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 10001))))
+        self.assertEqual(value0.data, 1)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -247,6 +247,25 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10001))))
         self.assertEqual(value0.data, 10000)
 
+    def test_mgmt_iface_description(self):
+        """
+        Test mgmt port description (which is simply an alias)
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 10001))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 10001))))
+        self.assertEqual(str(value0.data), 'mgmt1')
+
     def test_mgmt_iface_oper_status(self):
         """
         Test mgmt port operative status

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -228,3 +228,22 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 3, 1003))))
         self.assertEqual(value0.data, 161)
 
+    def test_mgmt_iface(self):
+        """
+        Test that mgmt port is present in the MIB
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10000))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10001))))
+        self.assertEqual(value0.data, 10000)
+

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -142,6 +142,17 @@ class TestLLDPMIB(TestCase):
             ret = mib_entry(sub_id=(1, num,))
             self.assertEqual(ret, num)
 
+    def test_mgmt_local_port_num(self):
+        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 2)]
+        ret = mib_entry(sub_id=(1, 10001,))
+        self.assertEqual(ret, 10001)
+
+    def test_mgmt_local_port_identification(self):
+        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
+        ret = mib_entry(sub_id=(10001,))
+        self.assertEquals(ret, b'mgmt1')
+        print(ret)
+
     def test_getnextpdu_local_port_identification(self):
         # oid.include = 1
         oid = ObjectIdentifier(11, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3))


### PR DESCRIPTION
Design doc: https://github.com/Azure/SONiC/wiki/SONiC-SMMP-Design-on-Management-Ports

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add management port support to Interface/LLDP MIBs

**- How I did it**
Implement this by getting management port info from MGMT_PORT_TABLE from APPL DB

**- How to verify it**
Insert some fake entries into MGMT_PORT_TABLE and make verify they are present in above MIBs

**- Description for the changelog**
Add managment port support to RFC1213, RFC2863, IEEE802.1ab MIBs
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


