### PR TITLE
Fix LLDP local port description field

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -269,11 +269,8 @@ class LocPortUpdater(MIBUpdater):
             return None
         counters = self.loc_port_data[if_name]
         _table_name = bytes(getattr(table_name, 'name', table_name), 'utf-8')
-        try:
-            return counters[_table_name]
-        except KeyError as e:
-            logger.warning(" 0 - b'PORT_TABLE' missing attribute '{}'.".format(e))
-            return None
+
+        return counters.get(_table_name, '')
 
     def port_id_subtype(self, sub_id):
         """


### PR DESCRIPTION
Return empty string if port description is not present in DB

Management port doesn't have description in DB so return empty instead of returning None

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

