### PR TITLE
[sonic_ax_impl/__main__.py]: Add signal handler to change debug level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ To run the daemon:
 $ python3.5 -m sonic_ax_impl [-d 10]
 ```
 
+
+To switch log level of already running snmp-subagent process
+
+1.) Find PID of the process.
+
+```
+root 42 1 12 06:37 ? 01:23:46 python3.6 -m sonic_ax_impl
+```
+
+2.) Send SIGUSR1 signal to Process
+```
+root@lnos-x1-a-csw04:/# kill -SIGUSR1 42
+```
+Sending SIGUSR1 signal to process again will reset the log level. 

--- a/src/sonic_ax_impl/__main__.py
+++ b/src/sonic_ax_impl/__main__.py
@@ -1,3 +1,4 @@
+from signal import signal, SIGUSR1
 import logging.handlers
 import os
 import shutil
@@ -11,6 +12,21 @@ from . import mibs
 
 LOG_FORMAT = "snmp-subagent [%(name)s] %(levelname)s: %(message)s"
 
+# set signal handlers to switch log level
+def signal_handler_sigusr1(signal, frame):
+    # set log level to debug or revert if set already
+    if sonic_ax_impl.logger.getEffectiveLevel() != logging.DEBUG:
+        sonic_ax_impl.logger.info("signal_handler_sigusr1(): Setting logger level to debug")
+        sonic_ax_impl.logger.setLevel(logging.DEBUG)
+        ax_interface.logger.setLevel(logging.DEBUG)
+    else:
+        sonic_ax_impl.logger.info("signal_handler_sigusr1(): Revert logger level to info")
+        sonic_ax_impl.logger.setLevel(logging.INFO)
+        ax_interface.logger.setLevel(logging.INFO)
+    return
+
+signal(SIGUSR1, signal_handler_sigusr1)
+# end signal handlers
 
 def install_file(src_filename, dest_dir, executable=False):
     dest_file = shutil.copy(src_filename, dest_dir)


### PR DESCRIPTION
[sonic_ax_impl/__main__.py]: Add signal handler to change debug level.    

Today, We can not alter the log level of already running snmp-subagent.
Adding a signal handler for signal SIGUSR1 to switch log level for both
sonic_ax_impl and ax_interface logger.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Today, We can not alter the log level of already running snmp-subagent.
Adding a signal handler for signal SIGUSR1 to switch log level for both
sonic_ax_impl and ax_interface logger.

**- How I did it**
Using Signal Handler. Same thing can be done using socket or a thread looking for some config/file but that eats more resources unnecessarily.

**- How to verify it**
admin@lnos-x1-a-csw04:~$ sudo service snmp restart <<<< [restart with latest code]

root@lnos-x1-a-csw04:/# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 06:37 ?        00:00:12 /usr/bin/python /usr/bin/supervisord
root        24     1  0 06:37 ?        00:00:00 /usr/sbin/rsyslogd -n
Debian-+    34     1  0 06:37 ?        00:00:07 /usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I 
root        42     1 12 06:37 ?        01:23:46 python3.6 -m sonic_ax_impl <<<< [Process 42]
root        44     0  0 06:38 ?        00:00:00 /bin/bash
root        52    44  0 17:59 ?        00:00:00 ps -ef


root@lnos-x1-a-csw04:/# kill -SIGUSR1 42 <<<< [Sent the signal]

Dec  4 06:38:30.578066 lnos-x1-a-csw04 INFO snmp-subagent [sonic_ax_impl] INFO: signal_handler_sigusr1(): Setting logger level to debug

Dec  4 06:38:42.733983 lnos-x1-a-csw04 DEBUG snmp-subagent [sonic_ax_impl] DEBUG: Updating CPU/Mem Utilization with: 33.9% / 52%
Dec  4 06:38:47.738111 lnos-x1-a-csw04 DEBUG snmp-subagent <<<< [log level moved to debug]
[sonic_ax_impl] DEBUG: Updating CPU/Mem Utilization with: 8.2% / 52%
Dec  4 06:38:51.740513 lnos-x1-a-csw04 DEBUG snmp-subagent [sonic_ax_impl] DEBUG: Updating CPU/Mem Utilization with: 15.6% / 52%


root@lnos-x1-a-csw04:/# kill -SIGUSR1 42 <<<< [Sent the signal again]
Dec  4 06:40:06.877337 lnos-x1-a-csw04 INFO snmp-subagent [sonic_ax_impl] INFO: signal_handler_sigusr1(): Revert logger level to info<<<< [log level switched to INFO]

**- Description for the changelog**
Signal Handler to switch log level of snmp-subagent process.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

