### PR TITLE
Remove verbose feature missing logs

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -277,8 +277,7 @@ class InterfacesUpdater(MIBUpdater):
 
         if oid in self.mgmt_oid_name_map:
             # TODO: mgmt counters not available through SNMP right now
-            # COUNTERS DB does not have suppot for generic linux (mgmt) interface counters
-            mibs.logger.warning('management interface counters not available through SNMP right now')
+            # COUNTERS DB does not have support for generic linux (mgmt) interface counters
             return 0
         elif oid in self.oid_lag_name_map:
             counter_value = 0

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -171,8 +171,7 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         if oid in self.mgmt_oid_name_map:
             # TODO: mgmt counters not available through SNMP right now
-            # COUNTERS DB does not have suppot for generic linux (mgmt) interface counters
-            mibs.logger.warning('management interface counters not available through SNMP right now')
+            # COUNTERS DB does not have support for generic linux (mgmt) interface counters
             return 0
 
         if oid in self.oid_lag_name_map:


### PR DESCRIPTION
This is too verbose for syslog. Since we have TODO comment, safe to remove.