### PR TITLE
integrating py.test into setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,10 @@ setup(
     name='asyncsnmp',
     install_requires=dependencies,
     setup_requires=["pytest-runner"],
-    tests_require=["pytest"],
+    tests_require=test_deps,
     version='2.1.0',
     packages=find_packages('src'),
     extras_require={
-        'testing': test_deps,
         'high_perf': high_performance_deps,
     },
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ high_performance_deps = [
 setup(
     name='asyncsnmp',
     install_requires=dependencies,
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
     version='2.1.0',
     packages=find_packages('src'),
     extras_require={


### PR DESCRIPTION
Signed-off-by: Sangita Maity samaity@linkedin.com

- **What I did**
Integrate py.test into setuptools as vanilla 'python3 setup.py test' does not work.
This PR is needed for snmp stretch upgrade docker PR.

1. [https://github.com/Azure/sonic-buildimage/pull/2620](https://github.com/Azure/sonic-buildimage/pull/2620)

- **How to verify it**
Use this PR with snmp docker upgrade PR in sonic-buildimage.

Ref: https://docs.pytest.org/en/latest/goodpractices.html