### PR TITLE
Add synchronization between SNMP MIBs and counters thread

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -136,6 +136,14 @@ def mgmt_if_entry_table_state_db(if_name):
 
     return b'MGMT_PORT_TABLE|' + if_name
 
+def fc_config_table(fc_group):
+    """
+    :param fc_group: flex counter group name
+    :return: FLEX_COUNTER_TABLE key
+    """
+
+    return b'FLEX_COUNTER_TABLE|' + fc_group
+
 
 def config(**kwargs):
     global redis_kwargs
@@ -382,6 +390,18 @@ def get_transceiver_sensor_sub_id(ifindex, sensor):
 
     transceiver_oid, = get_transceiver_sub_id(ifindex)
     return (transceiver_oid + SENSOR_PART_ID_MAP[sensor], )
+
+
+def get_fc_group_status(db_conn, fc_group):
+    """
+    :param db_conn: db connector
+    :param fc_group: flex counter group
+    :return: status
+    """
+
+    db_conn.connect(db_conn.CONFIG_DB)
+    return db_conn.get(db_conn.CONFIG_DB, fc_config_table(fc_group), 'FLEX_COUNTER_STATUS')
+
 
 class RedisOidTreeUpdater(MIBUpdater):
     def __init__(self, prefix_str):

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -169,6 +169,15 @@ class InterfacesUpdater(MIBUpdater):
         self.oid_sai_map = {}
         self.oid_name_map = {}
 
+    def check_ready(self):
+        """
+        Wait for port counters to be available
+        before start polling from DB
+        """
+
+        status = mibs.get_fc_group_status(self.db_conn, b'PORT')
+        return status == b'enable'
+
     def reinit_data(self):
         """
         Subclass update interface information

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -66,6 +66,15 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_name_lag_name_map = {}
         self.oid_lag_name_map = {}
 
+    def check_ready(self):
+        """
+        Wait for port counters to be available
+        before start polling from DB
+        """
+
+        status = mibs.get_fc_group_status(self.db_conn, b'PORT')
+        return status == b'enable'
+
     def reinit_data(self):
         """
         Subclass update interface information

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -27,6 +27,15 @@ class PfcUpdater(MIBUpdater):
         self.if_counters = {}
         self.if_range = []
 
+    def check_ready(self):
+        """
+        Wait for pfc counters to be available
+        before start polling from DB
+        """
+
+        status = mibs.get_fc_group_status(self.db_conn, b'PORT')
+        return status == b'enable'
+
     def reinit_data(self):
         """
         Subclass update interface information

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -65,6 +65,15 @@ class QueueStatUpdater(MIBUpdater):
 
         self.queue_type_map = {}
 
+    def check_ready(self):
+        """
+        Wait for queue counters to be available
+        before start polling from DB
+        """
+
+        status = mibs.get_fc_group_status(self.db_conn, b'QUEUE')
+        return status == b'enable'
+
     def reinit_data(self):
         """
         Subclass update interface information


### PR DESCRIPTION
Trying to address https://github.com/Azure/sonic-buildimage/issues/2750 by removing snmp.timer systemd unit and adding synchronization between counters and SNMP counter dependent MIBs

Added check_ready() interface to suspend reinit_data/update_data
untill a MIBUpdater child specific contition is met.

Used this approach to suspend counters dependent MIBs
untill counters polling thread is started.

check_ready() might be usefull for transceiver or other MIBs as well
but not scope of this change.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add synchronization mechanism to MIBUpdater
Wait for counters to be ready before start polling from COUNTERS DB

**- How I did it**
Added check_ready() interface

**- How to verify it**
- unittest
- SNMP ansible test on DUT

**- Description for the changelog**
Add synchronization mechanism to MIBUpdater
Wait for counters to be ready before start polling from COUNTERS DB

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

