### PR TITLE
Fix issue #104: lldpLocManAddrTable supports multiple IP addresses

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -306,13 +306,15 @@ class LLDPLocManAddrUpdater(MIBUpdater):
             logger.debug("Got mgmt ip from db : {}".format(self.mgmt_ip_str))
         try:
             addr_subtype_sub_oid = 4
-            mgmt_ip_sub_oid = ()
+            mgmt_ip_sub_oid = None
             for mgmt_ip in self.mgmt_ip_str.split(','):
                 if '.' in mgmt_ip:
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in mgmt_ip.split('.')])
                     break
         except ValueError:
             logger.error("Invalid local mgmt IP {}".format(self.mgmt_ip_str))
+            return
+        if mgmt_ip_sub_oid == None:
             return
         sub_oid = (ManAddrConst.man_addr_subtype_ipv4,
                    *mgmt_ip_sub_oid)

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -295,6 +295,8 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         """
         Subclass update data routine.
         """
+        self.man_addr_list = []
+
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
         mgmt_ip_bytes = self.db_conn.get(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE, b'lldp_loc_man_addr')

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -2,6 +2,7 @@
 http://www.ieee802.org/1/files/public/MIBs/LLDP-MIB-200505060000Z.txt
 """
 import ipaddress
+import json
 from enum import Enum, unique
 from bisect import bisect_right
 
@@ -302,11 +303,12 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         if not mgmt_ip_bytes:
             self.mgmt_ip_str = ''
         else:
-            self.mgmt_ip_str = mgmt_ip_bytes.decode()
+            self.mgmt_ip_str = mgmt_ip_bytes.decode('utf8').replace("'", '"').replace("u", '')
             logger.debug("Got mgmt ip from db : {}".format(self.mgmt_ip_str))
         try:
             addr_subtype_sub_oid = 4
-            mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in self.mgmt_ip_str.split('.')])
+            mgmt_ip_list = json.loads(self.mgmt_ip_str)
+            mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in mgmt_ip_list[0].split('.')])
         except ValueError:
             logger.error("Invalid local mgmt IP {}".format(self.mgmt_ip_str))
             return

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -306,13 +306,11 @@ class LLDPLocManAddrUpdater(MIBUpdater):
             logger.debug("Got mgmt ip from db : {}".format(self.mgmt_ip_str))
         try:
             addr_subtype_sub_oid = 4
-            try:
-                # Multiple "mgmt-ip"
-                self.mgmt_ip_str = eval(self.mgmt_ip_str)
-                mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in self.mgmt_ip_str[0].split('.')])
-            except SyntaxError:
-                # Single "mgmt-ip"
-                mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in self.mgmt_ip_str.split('.')])
+            mgmt_ip_sub_oid = ()
+            for mgmt_ip in self.mgmt_ip_str.split(','):
+                if '.' in mgmt_ip:
+                    mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in mgmt_ip.split('.')])
+                    break
         except ValueError:
             logger.error("Invalid local mgmt IP {}".format(self.mgmt_ip_str))
             return
@@ -346,10 +344,11 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         :param sub_id:
         :return: MGMT IP in HEX
         """
-        if isinstance(self.mgmt_ip_str, list):
-            hex_ip = " ".join([format(int(i), '02X') for i in self.mgmt_ip_str[0].split('.')])
-        else:
-            hex_ip = " ".join([format(int(i), '02X') for i in self.mgmt_ip_str.split('.')])
+        hex_ip = ''
+        for mgmt_ip in self.mgmt_ip_str.split(','):
+            if '.' in mgmt_ip:
+                hex_ip = " ".join([format(int(i), '02X') for i in mgmt_ip.split('.')])
+                break
         return hex_ip
 
     @staticmethod

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -466,7 +466,7 @@
     "lldp_loc_chassis_id": "00:11:22:AB:CD:EF",
     "lldp_loc_sys_name": "SONiC",
     "lldp_loc_sys_desc": "Gotta go Fast!",
-    "lldp_loc_man_addr": "10.224.25.26"
+    "lldp_loc_man_addr": "10.224.25.26,fe80::ce37:abff:feec:de9c"
   },
   "PORT_TABLE:Ethernet0": {
     "description": "snowflake",


### PR DESCRIPTION
1.0.8802.1.1.2.1.3.8 | lldpLocManAddrTable
-- | --

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxx "
Please provide the following information:
-->
fixes #104 

**- What I did**
**- How I did it**
>According source code, 
The mgmt_ip_bytes is got from the lldp_loc_man_addr field of LLDP_LOC_CHASSIS table in APPL_DB
The content of decoded mgmt_ip_str string will be "[u'240.127.1.1', u'fe80::ce37:abff:feec:de9c']".
To specify the separator '.' to split the mgmt_ip_str, will get ValueError: invalid literal for int() with base 10: "[u'240".
The mgmt_ip_str string can' t just decoded from mgmt_ip_bytes, shall filter some characters, e.g., u and '.

**- How to verify it**
>snmpwalk -v2c -c public 192.168.1.100 1.0.8802.1.1.2.1.3.8
iso.0.8802.1.1.2.1.3.8.1.1.1.4.10.1.0.1 = INTEGER: 1
iso.0.8802.1.1.2.1.3.8.1.3.1.4.10.1.0.1 = INTEGER: 5
iso.0.8802.1.1.2.1.3.8.1.4.1.4.10.1.0.1 = INTEGER: 2
iso.0.8802.1.1.2.1.3.8.1.5.1.4.10.1.0.1 = INTEGER: 0
iso.0.8802.1.1.2.1.3.8.1.6.1.4.10.1.0.1 = OID: iso.3.6.1.2.1.2.2.1.1

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

