### PR TITLE
Fix system capabilities parsing issue.

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -110,7 +110,8 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
         self.loc_chassis_data = self.db_conn.get_all(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE)
-
+        self.loc_chassis_data[b'lldp_loc_sys_cap_supported'] = bytearray([int (x, 16) for x in self.loc_chassis_data[b'lldp_loc_sys_cap_supported'].split()])
+        self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'] = bytearray([int (x, 16) for x in self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'].split()])
     def update_data(self):
         """
         Avoid NotImplementedError
@@ -430,7 +431,8 @@ class LLDPRemTableUpdater(MIBUpdater):
                 self.if_range.append((time_mark,
                                       if_oid,
                                       remote_index))
-
+                lldp_kvs[b'lldp_rem_sys_cap_supported'] = bytearray([int (x, 16) for x in lldp_kvs[b'lldp_rem_sys_cap_supported'].split()])
+                lldp_kvs[b'lldp_rem_sys_cap_enabled'] = bytearray([int (x, 16) for x in lldp_kvs[b'lldp_rem_sys_cap_enabled'].split()])
                 self.lldp_counters.update({if_name: lldp_kvs})
             except (KeyError, AttributeError) as e:
                 logger.warning("Exception when updating lldpRemTable: {}".format(e))

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -95,6 +95,8 @@ def poll_lldp_entry_updates(pubsub):
         return ret
     return data, interface, if_index
 
+def parse_sys_capability(sys_cap):
+    return bytearray([int (x, 16) for x in sys_cap.split()])
 
 class LLDPLocalSystemDataUpdater(MIBUpdater):
     def __init__(self):
@@ -110,8 +112,8 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
         self.loc_chassis_data = self.db_conn.get_all(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE)
-        self.loc_chassis_data[b'lldp_loc_sys_cap_supported'] = bytearray([int (x, 16) for x in self.loc_chassis_data[b'lldp_loc_sys_cap_supported'].split()])
-        self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'] = bytearray([int (x, 16) for x in self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'].split()])
+        self.loc_chassis_data[b'lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_supported'])
+        self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'])
     def update_data(self):
         """
         Avoid NotImplementedError
@@ -431,8 +433,8 @@ class LLDPRemTableUpdater(MIBUpdater):
                 self.if_range.append((time_mark,
                                       if_oid,
                                       remote_index))
-                lldp_kvs[b'lldp_rem_sys_cap_supported'] = bytearray([int (x, 16) for x in lldp_kvs[b'lldp_rem_sys_cap_supported'].split()])
-                lldp_kvs[b'lldp_rem_sys_cap_enabled'] = bytearray([int (x, 16) for x in lldp_kvs[b'lldp_rem_sys_cap_enabled'].split()])
+                lldp_kvs[b'lldp_rem_sys_cap_supported'] = parse_sys_capability(lldp_kvs[b'lldp_rem_sys_cap_supported'])
+                lldp_kvs[b'lldp_rem_sys_cap_enabled'] = parse_sys_capability(lldp_kvs[b'lldp_rem_sys_cap_enabled'])
                 self.lldp_counters.update({if_name: lldp_kvs})
             except (KeyError, AttributeError) as e:
                 logger.warning("Exception when updating lldpRemTable: {}".format(e))

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -466,6 +466,8 @@
     "lldp_loc_chassis_id": "00:11:22:AB:CD:EF",
     "lldp_loc_sys_name": "SONiC",
     "lldp_loc_sys_desc": "Gotta go Fast!",
+    "lldp_loc_sys_cap_enabled": "28 00",
+    "lldp_loc_sys_cap_supported": "28 00",
     "lldp_loc_man_addr": "10.224.25.26,fe80::ce37:abff:feec:de9c"
   },
   "PORT_TABLE:Ethernet0": {

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -202,3 +202,17 @@ class TestLLDPMIB(TestCase):
         print(response)
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.END_OF_MIB_VIEW)
+
+    def test_getnextpdu_lldpLocSysCapSupported(self):
+        oid = ObjectIdentifier(9, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 5))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 5))))
+        self.assertEqual(str(value0.data), "\x28\x00")

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -216,3 +216,45 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 5))))
         self.assertEqual(str(value0.data), "\x28\x00")
+
+    def test_getnextpdu_lldpLocSysCapEnabled(self):
+        oid = ObjectIdentifier(9, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 6))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 6))))
+        self.assertEqual(str(value0.data), "\x28\x00")
+
+    def test_getnextpdu_lldpRemSysCapSupported(self):
+        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 11, 1, 1))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 11, 1, 1))))
+        self.assertEqual(str(value0.data), "\x28\x00")
+
+    def test_getnextpdu_lldpRemSysCapEnabled(self):
+        oid = ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 12, 1, 1))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 12, 1, 1))))
+        self.assertEqual(str(value0.data), "\x28\x00")


### PR DESCRIPTION
**- What I did**
Fix system capabilities parsing issue.

**- How I did it**
For lldp_rem_sys_cap_supported, lldp_rem_sys_cap_enabled, lldp_loc_sys_cap_supported, and lldp_loc_sys_cap_enabled objects,
shall converts string to hex bytes.

**- How to verify it**
Before modified
> 
    D:\TOOL\snmp>snmpwalk -v2c -c public 192.168.1.100  1.0.8802.1.1.2.1.3
    iso.0.8802.1.1.2.1.3.1 = INTEGER: 4
    iso.0.8802.1.1.2.1.3.2 = STRING: "cc:37:ab:ec:de:9c"
    iso.0.8802.1.1.2.1.3.3 = STRING: "sonic"
    iso.0.8802.1.1.2.1.3.4 = STRING: "Debian GNU/Linux 9 (stretch) Linux 4.9.0-9-2-amd64 #1 SMP Debian 4.9.168-1+deb9u3 (2015-12-19) x86_64"
    iso.0.8802.1.1.2.1.3.5 = STRING: "28 00"                         ==> error
    iso.0.8802.1.1.2.1.3.6 = STRING: "28 00"                          ==> error
    

    D:\TOOL\snmp>snmpwalk -v2c -c public 192.168.1.100  1.0.8802.1.1.2.1.4.1.1
    iso.0.8802.1.1.2.1.4.1.1.1.1003.1.1 = Timeticks: (1003) 0:00:10.03
    iso.0.8802.1.1.2.1.4.1.1.2.1003.1.1 = INTEGER: 1
    iso.0.8802.1.1.2.1.4.1.1.3.1003.1.1 = INTEGER: 1
    iso.0.8802.1.1.2.1.4.1.1.4.1003.1.1 = INTEGER: 4
    iso.0.8802.1.1.2.1.4.1.1.5.1003.1.1 = STRING: "80:22:07:33:65:01"
    iso.0.8802.1.1.2.1.4.1.1.6.1003.1.1 = INTEGER: 3
    iso.0.8802.1.1.2.1.4.1.1.7.1003.1.1 = STRING: "80:22:07:33:65:1a"
    iso.0.8802.1.1.2.1.4.1.1.8.1003.1.1 = STRING: "Ethernet Port on unit 1, port 25"
    iso.0.8802.1.1.2.1.4.1.1.9.1003.1.1 = ""
    iso.0.8802.1.1.2.1.4.1.1.10.1003.1.1 = STRING: "ECS4120-28T"
    iso.0.8802.1.1.2.1.4.1.1.11.1003.1.1 = STRING: "28 00"      ==> error
    iso.0.8802.1.1.2.1.4.1.1.12.1003.1.1 = STRING: "28 00"      ==> error
![before_modified](https://user-images.githubusercontent.com/18656014/63139086-91858580-c00f-11e9-9a57-bdd3422f444f.png)

After modified
> 
    D:\TOOL\snmp>snmpwalk -v2c -c public 192.168.1.100  1.0.8802.1.1.2.1.3
    iso.0.8802.1.1.2.1.3.1 = INTEGER: 4
    iso.0.8802.1.1.2.1.3.2 = STRING: "cc:37:ab:ec:de:9c"
    iso.0.8802.1.1.2.1.3.3 = STRING: "sonic"
    iso.0.8802.1.1.2.1.3.4 = STRING: "Debian GNU/Linux 9 (stretch) Linux 4.9.0-9-2-amd64 #1 SMP Debian 4.9.168-1+deb9u3 (2015-12-19) x86_64"
    iso.0.8802.1.1.2.1.3.5 = Hex-STRING: 28 00                      ==> OK
    iso.0.8802.1.1.2.1.3.6 = Hex-STRING: 28 00                      ==> OK

    D:\TOOL\snmp>snmpwalk -v2c -c public 192.168.1.100  1.0.8802.1.1.2.1.4.1.1
    iso.0.8802.1.1.2.1.4.1.1.1.1344.1.1 = Timeticks: (1344) 0:00:13.44
    iso.0.8802.1.1.2.1.4.1.1.2.1344.1.1 = INTEGER: 1
    iso.0.8802.1.1.2.1.4.1.1.3.1344.1.1 = INTEGER: 1
    iso.0.8802.1.1.2.1.4.1.1.4.1344.1.1 = INTEGER: 4
    iso.0.8802.1.1.2.1.4.1.1.5.1344.1.1 = STRING: "80:22:07:33:65:01"
    iso.0.8802.1.1.2.1.4.1.1.6.1344.1.1 = INTEGER: 3
    iso.0.8802.1.1.2.1.4.1.1.7.1344.1.1 = STRING: "80:22:07:33:65:1a"
    iso.0.8802.1.1.2.1.4.1.1.8.1344.1.1 = STRING: "Ethernet Port on unit 1, port 25"
    iso.0.8802.1.1.2.1.4.1.1.9.1344.1.1 = ""
    iso.0.8802.1.1.2.1.4.1.1.10.1344.1.1 = STRING: "ECS4120-28T"
    iso.0.8802.1.1.2.1.4.1.1.11.1344.1.1 = Hex-STRING: 28 00   ==> OK
    iso.0.8802.1.1.2.1.4.1.1.12.1344.1.1 = Hex-STRING: 28 00   ==> OK
![after_modified](https://user-images.githubusercontent.com/18656014/63139095-99ddc080-c00f-11e9-80d6-ca1305258d75.png)

**- Description for the changelog**

Signed-off-by: kelly_chen@edge-core.com

