### PR TITLE
Fix index nodes in LLDP tables whose access right is not-accessible.

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -668,8 +668,6 @@ class LLDPLocalSystemData(metaclass=MIBMeta, prefix='.1.0.8802.1.1.2.1.3'):
 
         # lldpLocPortEntry = '1'
 
-        lldpLocPortNum = SubtreeMIBEntry('1.1', port_updater, ValueType.INTEGER, port_updater.local_port_num)
-
         # We're using locally assigned name, so according to textual convention, the subtype is 7
         lldpLocPortIdSubtype = SubtreeMIBEntry('1.2', port_updater, ValueType.INTEGER, port_updater.port_id_subtype)
 
@@ -690,12 +688,6 @@ class LLDPLocalSystemData(metaclass=MIBMeta, prefix='.1.0.8802.1.1.2.1.3'):
         ::= { lldpLocalSystemData 8 }
         """
         updater = LLDPLocManAddrUpdater()
-
-        lldpLocManAddrSubtype = SubtreeMIBEntry('1.1', updater, ValueType.INTEGER,
-                                                updater.lookup, updater.man_addr_subtype)
-
-        lldpLocManAddr = SubtreeMIBEntry('1.2', updater, ValueType.OCTET_STRING,
-                                         updater.lookup, updater.man_addr)
 
         lldpLocManAddrLen = SubtreeMIBEntry('1.3', updater, ValueType.INTEGER,
                                             updater.lookup, updater.man_addr_len)
@@ -800,17 +792,6 @@ class LLDPRemTable(metaclass=MIBMeta, prefix='.1.0.8802.1.1.2.1.4.1'):
     """
     lldp_updater = LLDPRemTableUpdater()
 
-    lldpRemTimeMark = \
-        SubtreeMIBEntry('1.1', lldp_updater, ValueType.TIME_TICKS, lldp_updater.lldp_table_lookup_integer,
-                        LLDPRemoteTables(1))
-
-    lldpRemLocalPortNum = \
-        SubtreeMIBEntry('1.2', lldp_updater, ValueType.INTEGER, lldp_updater.local_port_num)
-
-    lldpRemIndex = \
-        SubtreeMIBEntry('1.3', lldp_updater, ValueType.INTEGER, lldp_updater.lldp_table_lookup_integer,
-                        LLDPRemoteTables(3))
-
     lldpRemChassisIdSubtype = \
         SubtreeMIBEntry('1.4', lldp_updater, ValueType.INTEGER, lldp_updater.lldp_table_lookup_integer,
                         LLDPRemoteTables(4))
@@ -861,12 +842,6 @@ class LLDPRemManAddrTable(metaclass=MIBMeta, prefix='.1.0.8802.1.1.2.1.4.2'):
     ::= { lldpRemoteSystemsData 2 }
     """
     updater = LLDPRemManAddrUpdater()
-
-    lldpRemManAddrSubtype = SubtreeMIBEntry('1.1', updater, ValueType.INTEGER,
-                                            updater.lookup, updater.man_addr_subtype)
-
-    lldpRemManAddr = SubtreeMIBEntry('1.2', updater, ValueType.OCTET_STRING,
-                                     updater.lookup, updater.man_addr)
 
     lldpRemManAddrIfSubtype = SubtreeMIBEntry('1.3', updater, ValueType.INTEGER,
                                               updater.lookup, updater.man_addr_if_subtype)

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -68,14 +68,14 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(str(value0.data), "Ethernet2")
 
     def test_subtype_lldp_rem_table(self):
-        for entry in range(2, 13):
+        for entry in range(4, 13):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, entry)]
             ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
             print(ret)
 
     def test_subtype_lldp_loc_port_table(self):
-        for entry in range(1, 5):
+        for entry in range(2, 5):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, entry)]
             ret = mib_entry(sub_id=(1,))
             self.assertIsNotNone(ret)
@@ -89,63 +89,24 @@ class TestLLDPMIB(TestCase):
             print(ret)
 
     def test_subtype_lldp_loc_man_addr_table(self):
-        for entry in range(1, 7):
+        for entry in range(3, 7):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 8, 1, entry)]
             ret = mib_entry(sub_id=(1,))
             self.assertIsNotNone(ret)
             print(ret)
 
     def test_subtype_lldp_rem_man_addr_table(self):
-        for entry in range(1, 6):
+        for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
             print(ret)
-
-    def test_ipv4_rem_man_addr(self):
-        # ethernet0 has IPv4 remote management address
-        interface_number = 1
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 2)]
-        ret = mib_entry(sub_id=(1, interface_number,))
-        self.assertEquals(ret, "0A E0 19 64")
-        print(ret)
-        # test remManAddrSubtype
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 1)]
-        ret = mib_entry(sub_id=(1, interface_number,))
-        # subtype 1 means IPv4
-        self.assertEquals(ret, 1)
-        print(ret)
-
-    def test_ipv6_rem_man_addr(self):
-        # ethernet4 has IPv6 remote management address
-        interface_number = 5
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 2)]
-        ret = mib_entry(sub_id=(1, interface_number,))
-        self.assertEquals(ret, "fe80 0 268a 7ff fe3f 834c")
-        print(ret)
-        # test remManAddrSubtype
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 1)]
-        ret = mib_entry(sub_id=(1, interface_number,))
-        # subtype 2 means IPv6
-        self.assertEquals(ret, 2)
-        print(ret)
 
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(1,))
         self.assertEquals(ret, b'etp1')
         print(ret)
-
-    def test_local_port_num(self):
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 2)]
-        for num in range(1, 126, 4):
-            ret = mib_entry(sub_id=(1, num,))
-            self.assertEqual(ret, num)
-
-    def test_mgmt_local_port_num(self):
-        mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 2)]
-        ret = mib_entry(sub_id=(1, 10001,))
-        self.assertEqual(ret, 10001)
 
     def test_mgmt_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]


### PR DESCRIPTION
**- What I did**

Ensure `not-accessible` nodes (index nodes in MIB table) in tables in LLDP MIB are not readable by SNMP get operation.

**- How I did it**

Remove the code which processes read request of index nodes and their access right (`MAX-ACCESS` caluse) are `not-accessible`:

* Index node `lldpLocPortNum` in `lldpLocPortTable`,
* Index nodes `lldpLocManAddrSubtype` and `lldpLocManAddr` in `lldpLocManAddrTable`,
* Index nodes `lldpRemTimeMark`, `lldpRemLocalPortNum` and `lldpRemIndex` in `lldpRemTable`, and
* Index nodes `lldpRemManAddrSubtype` and `lldpRemManAddr` in `lldpRemManAddrTable` tables

**- How to verify it**

Before modified

    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.7.1.1
    iso.0.8802.1.1.2.1.3.7.1.1.1 = INTEGER: 1
    iso.0.8802.1.1.2.1.3.7.1.1.5 = INTEGER: 5
    iso.0.8802.1.1.2.1.3.7.1.1.9 = INTEGER: 9
    iso.0.8802.1.1.2.1.3.7.1.1.13 = INTEGER: 13
    iso.0.8802.1.1.2.1.3.7.1.1.17 = INTEGER: 17
    iso.0.8802.1.1.2.1.3.7.1.1.21 = INTEGER: 21
    iso.0.8802.1.1.2.1.3.7.1.1.25 = INTEGER: 25
    iso.0.8802.1.1.2.1.3.7.1.1.29 = INTEGER: 29
    iso.0.8802.1.1.2.1.3.7.1.1.33 = INTEGER: 33
    iso.0.8802.1.1.2.1.3.7.1.1.37 = INTEGER: 37
    iso.0.8802.1.1.2.1.3.7.1.1.41 = INTEGER: 41
    iso.0.8802.1.1.2.1.3.7.1.1.45 = INTEGER: 45
    iso.0.8802.1.1.2.1.3.7.1.1.49 = INTEGER: 49
    iso.0.8802.1.1.2.1.3.7.1.1.53 = INTEGER: 53
    iso.0.8802.1.1.2.1.3.7.1.1.57 = INTEGER: 57
    iso.0.8802.1.1.2.1.3.7.1.1.61 = INTEGER: 61
    iso.0.8802.1.1.2.1.3.7.1.1.65 = INTEGER: 65
    iso.0.8802.1.1.2.1.3.7.1.1.69 = INTEGER: 69
    iso.0.8802.1.1.2.1.3.7.1.1.73 = INTEGER: 73
    iso.0.8802.1.1.2.1.3.7.1.1.77 = INTEGER: 77
    iso.0.8802.1.1.2.1.3.7.1.1.81 = INTEGER: 81
    iso.0.8802.1.1.2.1.3.7.1.1.85 = INTEGER: 85
    iso.0.8802.1.1.2.1.3.7.1.1.89 = INTEGER: 89
    iso.0.8802.1.1.2.1.3.7.1.1.93 = INTEGER: 93
    iso.0.8802.1.1.2.1.3.7.1.1.97 = INTEGER: 97
    iso.0.8802.1.1.2.1.3.7.1.1.101 = INTEGER: 101
    iso.0.8802.1.1.2.1.3.7.1.1.105 = INTEGER: 105
    iso.0.8802.1.1.2.1.3.7.1.1.109 = INTEGER: 109
    iso.0.8802.1.1.2.1.3.7.1.1.113 = INTEGER: 113
    iso.0.8802.1.1.2.1.3.7.1.1.117 = INTEGER: 117
    iso.0.8802.1.1.2.1.3.7.1.1.121 = INTEGER: 121
    iso.0.8802.1.1.2.1.3.7.1.1.125 = INTEGER: 125
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.8.1.1
    iso.0.8802.1.1.2.1.3.8.1.1.1.4.10.1.0.1 = INTEGER: 1
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.8.1.2
    iso.0.8802.1.1.2.1.3.8.1.2.1.4.10.1.0.1 = STRING: "0A 01 00 01"
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.1
    iso.0.8802.1.1.2.1.4.1.1.1.659.113.2 = Timeticks: (659) 0:00:06.59
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.2
    iso.0.8802.1.1.2.1.4.1.1.2.659.113.2 = INTEGER: 113
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.3
    iso.0.8802.1.1.2.1.4.1.1.3.669.113.2 = INTEGER: 2
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.2.1.1
    iso.0.8802.1.1.2.1.4.2.1.1.649.113.2.1.4.192.168.3.20 = INTEGER: 1
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.2.1.2
    iso.0.8802.1.1.2.1.4.2.1.2.649.113.2.1.4.192.168.3.20 = STRING: "C0 A8 03 14"

After modified

    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.7.1.1
    iso.0.8802.1.1.2.1.3.7.1.1 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.8.1.1
    iso.0.8802.1.1.2.1.3.8.1.1 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.3.8.1.2
    iso.0.8802.1.1.2.1.3.8.1.2 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.1
    iso.0.8802.1.1.2.1.4.1.1.1 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.2
    iso.0.8802.1.1.2.1.4.1.1.2 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.1.1.3
    iso.0.8802.1.1.2.1.4.1.1.3 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.2.1.1
    iso.0.8802.1.1.2.1.4.2.1.1 = No Such Object available on this agent at this OID
    # snmpwalk -c public -v 2c 192.168.3.19 1.0.8802.1.1.2.1.4.2.1.2
    iso.0.8802.1.1.2.1.4.2.1.2 = No Such Object available on this agent at this OID
