### PR TITLE
Reduce syslog warnings when ConfigDB has no management ports

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -165,7 +165,7 @@ def init_mgmt_interface_tables(db_conn):
     mgmt_ports_keys = db_conn.keys(CONFIG_DB, mgmt_if_entry_table(b'*'))
 
     if not mgmt_ports_keys:
-        logger.warning('No managment ports found in {}'.format(mgmt_if_entry_table(b'')))
+        logger.debug('No managment ports found in {}'.format(mgmt_if_entry_table(b'')))
         return {}, {}
 
     mgmt_ports = [key.split(mgmt_if_entry_table(b''))[-1] for key in mgmt_ports_keys]

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -497,6 +497,10 @@ class LLDPRemManAddrUpdater(MIBUpdater):
             return
         try:
             mgmt_ip_str = lldp_kvs[b'lldp_rem_man_addr'].decode()
+            mgmt_ip_str = mgmt_ip_str.strip()
+            if len(mgmt_ip_str) == 0:
+                # the peer advertise an emtpy mgmt address
+                return
             time_mark = int(lldp_kvs[b'lldp_rem_time_mark'])
             remote_index = int(lldp_kvs[b'lldp_rem_index'])
             subtype = self.get_subtype(mgmt_ip_str)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In some use cases, the ConfigDB has no management ports at all. Then we see verbose warnings in syslog:
```
Oct  7 23:52:37.279295 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:52:50.186946 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:52:52.895705 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:52:56.769412 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:52:56.769507 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid mgmt IP
Oct  7 23:52:56.770222 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid management IP
Oct  7 23:52:56.770952 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid mgmt IP
Oct  7 23:52:56.771585 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid management IP
Oct  7 23:52:56.772216 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid mgmt IP
Oct  7 23:52:56.772787 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid management IP
Oct  7 23:52:56.773086 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid mgmt IP
Oct  7 23:52:56.773314 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Invalid management IP
Oct  7 23:53:01.508231 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:53:53.319509 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
Oct  7 23:53:57.376301 sonic WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: No managment ports found in b'MGMT_PORT|'
```
I try to remove all the repeated warnings.

**- How I did it**

**- How to verify it**
Tested in DUT.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

