### PR TITLE
Using get API to obtain dbid instead of internal var directly

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -224,7 +224,7 @@ class LocPortUpdater(MIBUpdater):
         """
         if not self.pubsub:
             redis_client = self.db_conn.get_redis_client(self.db_conn.APPL_DB)
-            db = self.db_conn.db_map[self.db_conn.APPL_DB]["db"]
+            db = self.db_conn.get_dbid(self.db_conn.APPL_DB)
             self.pubsub = redis_client.pubsub()
             self.pubsub.psubscribe("__keyspace@{}__:{}".format(db, mibs.lldp_entry_table(b'*')))
 
@@ -534,7 +534,7 @@ class LLDPRemManAddrUpdater(MIBUpdater):
         """
         if not self.pubsub:
             redis_client = self.db_conn.get_redis_client(self.db_conn.APPL_DB)
-            db = self.db_conn.db_map[self.db_conn.APPL_DB]["db"]
+            db = self.db_conn.get_dbid(self.db_conn.APPL_DB)
             self.pubsub = redis_client.pubsub()
             self.pubsub.psubscribe("__keyspace@{}__:{}".format(db, mibs.lldp_entry_table(b'*')))
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -193,7 +193,7 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         # does not support pubsub
         if not self.pubsub:
             redis_client = self.statedb.get_redis_client(self.statedb.STATE_DB)
-            db = self.statedb.db_map[self.statedb.STATE_DB]["db"]
+            db = self.statedb.get_dbid(self.statedb.STATE_DB)
             self.pubsub = redis_client.pubsub()
             self.pubsub.psubscribe("__keyspace@{}__:{}".format(db, self.TRANSCEIVER_KEY_PATTERN))
 


### PR DESCRIPTION
* application should use get api to obtain dbid instead of accessing internal variable  

* later for multi DB changes, we will redesign the internal db_map variable and implementation of get_dbid API , so to avoid breakage, we should use API to obtain dbid and merge snmpagent first.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com