### PR TITLE
UnavailableDataError for Key "COUNTERS_PORT_NAME_MAP" in COUNTERS_DB …

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -34,6 +34,10 @@ class MIBUpdater:
     async def start(self):
         # Run the update while we are allowed
         while self.run_event.is_set():
+            # wait based on our update frequency before executing again.
+            # randomize to avoid concurrent update storms.
+            await asyncio.sleep(self.frequency + random.randint(-2, 2))
+
             try:
                 # reinit internal structures
                 if self.update_counter > self.reinit_rate:
@@ -46,11 +50,7 @@ class MIBUpdater:
                 self.update_data()
             except Exception:
                 # Any unexpected exception or error, log it and keep running
-                logger.exception("MIBUpdater.start() caught an unexpected exception during update_data()")
-
-            # wait based on our update frequency before executing again.
-            # randomize to avoid concurrent update storms.
-            await asyncio.sleep(self.frequency + random.randint(-2, 2))
+                logger.warning("MIBUpdater.start() caught an unexpected exception during update_data()", exc_info=True)
 
     def reinit_data(self):
         """

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -325,10 +325,10 @@ def init_sync_d_queue_tables(db_conn):
     if not port_queues_map:
         # In the event no queue exists that follows the SONiC pattern, no OIDs are able to be registered.
         # A RuntimeError here will prevent the 'main' module from loading. (This is desirable.)
-        logger.error("No queues found in the Counter DB. SyncD database is incoherent.")
+        logger.warning("No queues found in the Counter DB. SyncD database is incoherent.")
         raise RuntimeError('The port_queues_map is not defined')
     elif not queue_stat_map:
-        logger.error("No queue stat counters found in the Counter DB. SyncD database is incoherent.")
+        logger.warning("No queue stat counters found in the Counter DB. SyncD database is incoherent.")
         raise RuntimeError('The queue_stat_map is not defined')
 
     for queues in port_queue_list_map.values():


### PR DESCRIPTION
The root cause is that SNMP may query queue_stat_map before it's created.  
SNMP would try to query again after 3-7 seconds, so it wouldn't actually affect others.  
So we modify the following:
- logging level from error to warning when SNMP query failed
- move sleep before it queries

Signed-off-by: jerry_chang jerry_chang@edge-core.com