### PR TITLE
Fix bug: if one mgmt port does not exist in StateDB, treat the oper/admin status as unknown

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -337,7 +337,7 @@ class InterfacesUpdater(MIBUpdater):
         else:
             return None
 
-        return self.db_conn.get_all(db, if_table, blocking=True)
+        return self.db_conn.get_all(db, if_table, blocking=False)
 
     def _get_status(self, sub_id, key):
         """
@@ -347,7 +347,12 @@ class InterfacesUpdater(MIBUpdater):
         """
         status_map = {
             b"up": 1,
-            b"down": 2
+            b"down": 2,
+            b"testing": 3,
+            b"unknown": 4,
+            b"dormant": 5,
+            b"notPresent": 6,
+            b"lowerLayerDown": 7
         }
 
         # Once PORT_TABLE will be moved to CONFIG DB
@@ -357,11 +362,12 @@ class InterfacesUpdater(MIBUpdater):
             entry = self._get_if_entry_state_db(sub_id)
         else:
             entry = self._get_if_entry(sub_id)
+
         if not entry:
-            return
+            return status_map.get(b"unknown")
 
         # Note: If interface never become up its state won't be reflected in DB entry
-        # If state is not in DB entry assume interface is down
+        # If state key is not in DB entry assume interface is down
         state = entry.get(key, b"down")
 
         return status_map.get(state, status_map[b"down"])

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -8,5 +8,11 @@
     "admin_status": "up",
     "alias": "mgmt1",
     "speed": 1000
+  },
+  "MGMT_PORT|eth2": {
+    "description": "NotExistInStateDB",
+    "admin_status": "up",
+    "alias": "mgmt2",
+    "speed": 1000
   }
 }

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -289,6 +289,25 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10001))))
         self.assertEqual(value0.data, 1)
 
+    def test_mgmt_iface_oper_status_unknown(self):
+        """
+        Test mgmt port operative status
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10002))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 10002))))
+        self.assertEqual(value0.data, 4)
+
     def test_mgmt_iface_admin_status(self):
         """
         Test mgmt port admin status


### PR DESCRIPTION
Fix bug: if one mgmt port does not exist in StateDB, treat the oper/admin status as unknown.

Currently it will throw exception:
```
ERROR:ax_interface:SubtreeMIBEntry.__call__() caught an unexpected exception during _callable_.__call__()
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 196, in __call__
    return self._callable_.__call__(sub_id, *self._callable_args)
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 381, in get_oper_status
    return self._get_status(sub_id, b"oper_status")
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 357, in _get_status
    entry = self._get_if_entry_state_db(sub_id)
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 340, in _get_if_entry_state_db
    return self.db_conn.get_all(db, if_table, blocking=True)
  File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 38, in wrapped
    ret_data = f(inst, db_name, *args, **kwargs)
```