### PR TITLE
Fix Quagga/FRR parser on IPv6 BGP sessions

### DIFF
--- a/src/sonic_ax_impl/lib/quaggaclient.py
+++ b/src/sonic_ax_impl/lib/quaggaclient.py
@@ -22,15 +22,17 @@ def parse_bgp_summary(summ):
         l = ls[li]
         if l.startswith('Neighbor        '):
             break
-        if l.startswith('No IPv'): # eg. No IPv6 neighbor is configured
+        if l.startswith('No IPv'): # eg. No IPv6 neighbor is configured, in Quagga (version 0.99.24.1)
             return bgpinfo
-        if l.endswith('> exit'): # last command in the lines
+        if l.startswith('% No BGP neighbors found'): # in FRRouting (version 7.2)
+            return bgpinfo
+        if l.endswith('> '): # directly hostname prompt, in FRRouting (version 4.0)
             return bgpinfo
         li += 1
 
     ## Read and store the table header
     if li >= n:
-        raise ValueError('No table header found')
+        raise ValueError('No table header found: ' + summ)
     hl = ls[li]
     li += 1
     ht = re.split('\s+', hl.rstrip())

--- a/tests/mock_tables/bgpsummary_ipv6_nobgp.txt
+++ b/tests/mock_tables/bgpsummary_ipv6_nobgp.txt
@@ -1,4 +1,1 @@
-Hello, this is Quagga (version 0.99.24.1).                                                                                                                            Copyright 1996-2005 Kunihiro Ishiguro, et al.                                                                                                                                                                                                                                                                                                                                                                                                                                                                     User Access Verification                                                                                                                                              
-"Password:
-str-msn2700-05> show ipv6 bgp summary
-str-msn2700-05> exit
+show ip bgp ipv6 summary

--- a/tests/test_vtysh.py
+++ b/tests/test_vtysh.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
+INPUT_DIR = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
+sys.path.insert(0, os.path.join(modules_path, 'tests'))
 
 from unittest import TestCase
 from unittest.mock import patch, mock_open
@@ -17,6 +19,7 @@ from ax_interface.constants import PduTypes
 from sonic_ax_impl.mibs.ietf import rfc4363
 from sonic_ax_impl.main import SonicMIB
 from sonic_ax_impl.lib.quaggaclient import parse_bgp_summary
+from mock_tables.socket import MockGetHostname
 
 class TestSonicMIB(TestCase):
     @classmethod
@@ -106,10 +109,13 @@ class TestSonicMIB(TestCase):
         self.assertEqual(str(value0.name), str(oid))
         self.assertEqual(value0.data, 6)
 
-    def parse_no_bgp():
-        filename = 'bgpsummary_ipv6_nobgp.txt'
+    def test_parse_no_bgp(self):
+        filename = INPUT_DIR + '/mock_tables/bgpsummary_ipv6_nobgp.txt'
         with open(filename, 'rb') as f:
             bgpsu = f.read()
+        hostname = MockGetHostname()
+        prompt_hostname = ('\r\n' + hostname + '> ').encode()
+        bgpsu += prompt_hostname
+        bgpsu = bgpsu.decode('ascii', 'ignore')
         bgpsumm_ipv6 = parse_bgp_summary(bgpsu)
         self.assertEqual(bgpsumm_ipv6, [])
-


### PR DESCRIPTION
If there is no ipv4 or ipv6 BGP neighbors configured, the messages are a little different in different Quagga/FRR version.

Quagga in 201811
```
sonic> show ipv6 bgp su
No IPv6 neighbor is configured
sonic> 
```
FRR in 201811

```
sonic> show ip bgp ipv6 summary
sonic>
```

FRR in master

```
sonic> show ip bgp ipv6 summary
% No BGP neighbors found
sonic> 
```
 Currently we could not handle 2nd or 3rd cases.