### PR TITLE
Fix exception when running snmp subagent under python3.7

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -281,8 +281,7 @@ class MIBTable(dict):
             updater.run_event = event
             fut = asyncio.ensure_future(updater.start())
             fut.add_done_callback(MIBTable._done_background_task_callback)
-            task = event._loop.create_task(fut)
-            tasks.append(task)
+            tasks.append(fut)
         return asyncio.gather(*tasks, loop=event._loop)
 
     def _find_parent_prefix(self, item):


### PR DESCRIPTION

**- What I did**
As part of converting the snmp docker to buster, I observed that the snmp subagent exits after throwing an exception.

```
May  5 21:35:16.852142 sonic ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Uncaught exception in sonic_ax_impl.main#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/main.py", line 70, in main#012    event_loop.run_until_complete(agent.run_in_event_loop())#012  File "/usr/lib/python3.7/asyncio/base_events.py", line 584, in run_until_complete#012    return future.result()#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/agent.py", line 37, in run_in_event_loop#012    background_task = self.mib_table.start_background_tasks(self.oid_updaters_enabled)#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 276, in start_background_tasks#012    task = event._loop.create_task(fut)#012  File "/usr/lib/python3.7/asyncio/base_events.py", line 405, in create_task#012    task = tasks.Task(coro, loop=self)#012TypeError: a coroutine was expected, got <Task pending coro=<MIBUpdater.start() running at /usr/local/lib/python3.7/dist-packages/ax_interface/mib.py:34> cb=[MIBTable._done_background_task_callback() at /usr/local/lib/python3.7/dist-packages/ax_interface/mib.py:263]>
```

The change also addresses the issue where snmp subagent doesnt exit on SIGTERM.

**- How I did it**
Code change.

**- How to verify it**
Verify that subagent is running in the docker.
snmpwalk -c public -v2c <ip> .1.3.6.1.2.1.2.2.1.2

**- Description for the changelog**
Fix exception when running snmp subagent under python3.7

