### PR TITLE
[ieee802_1ab]Ensuring that the LLDP_system_data is non-empty before getting field from it.

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -113,6 +113,8 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
         # establish connection to application database.
         Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.loc_chassis_data = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE)
+        if not self.loc_chassis_data:
+            return
         self.loc_chassis_data[b'lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_supported'])
         self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'])
     def update_data(self):
@@ -124,6 +126,8 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
 
     def table_lookup(self, table_name):
         try:
+            if not self.loc_chassis_data:
+                return None
             _table_name = bytes(getattr(table_name, 'name', table_name), 'utf-8')
             return self.loc_chassis_data[_table_name]
         except KeyError as e:


### PR DESCRIPTION

Signed-off-by: sundandan <sundandan@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**What I did**
Add a non-empty protection before getting field form local_chassis_date.

**Why I did it**
As the logic in sonic-dbsyncd, there will be no 'LLDP_LOC_CHASSIS' table in APP DB until  we establish neighbor relationships with LLDP neighbors. 
When there is no 'LLDP_LOC_CHASSIS' table in APP DB, walk node .1.0.8802.1.1.2.1.3 will led to error log:

> Jun  4 03:30:18.191672 leaf-229 ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 37, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 115, in reinit_data#012    self.loc_chassis_data[b'lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_supported'])#012TypeError: 'NoneType' object is not subscriptable

**How I verified it**
The error log described above does not appear anymore.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

