### PR TITLE
[Namespace]: Fix SNMP AgentX  socket connection timeout when using Namespace.get_all() 

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,12 +552,12 @@ class Namespace:
         db get_all function executed on global and all namespace DBs.
         """
         result = {}
+        # If there are multiple namespaces, _hash might not be 
+        # present in all namespace, ignore if not present in a
+        # specfic namespace.
         if (len(dbs) > 1) : kwargs['blocking'] = False
         for db_conn in dbs:
             db_conn.connect(db_name)
-            # If there are multiple namespaces, _hash might not be 
-            # present in all namespace, ignore if not present in a
-            # specfic namespace.
             ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
             if ns_result is not None:
                 result.update(ns_result)

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,7 +552,7 @@ class Namespace:
         # If there are multiple namespaces, _hash might not be 
         # present in all namespace, ignore if not present in a
         # specfic namespace.
-        if len(dbs) > 1: 
+        if len(dbs) > 1:
             kwargs['blocking'] = False
         for db_conn in dbs:
             ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -553,9 +553,12 @@ class Namespace:
         # present in all namespace, ignore if not present in a
         # specfic namespace.
         if len(dbs) > 1:
-            kwargs['blocking'] = False
+            tmp_kwargs = kwargs.copy()
+            tmp_kwargs['blocking'] = False
+        else:
+            tmp_kwargs = kwargs
         for db_conn in dbs:
-            ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
+            ns_result = db_conn.get_all(db_name, _hash, *args, **tmp_kwargs)
             if ns_result is not None:
                 result.update(ns_result)
         return result

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,12 +552,16 @@ class Namespace:
         db get_all function executed on global and all namespace DBs.
         """
         result = {}
+        Namespace.connect_all_dbs(dbs, db_name)
+        if len(dbs) == 1:
+            return dbs[0].get_all(db_name, _hash, *args, **kwargs)
         for db_conn in dbs:
-            db_conn.connect(db_name)
-            if(db_conn.exists(db_name, _hash)):
-                ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
-                if ns_result is not None:
-                    result.update(ns_result)
+            # If there are multiple namespaces, _hash might not be 
+            # present in all namespace, ignore if not present in a
+            # specfic namespace.
+            ns_result = db_conn.get_all(db_name, _hash, blocking=False)
+            if ns_result is not None:
+                result.update(ns_result)
         return result
 
     @staticmethod

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,14 +552,13 @@ class Namespace:
         db get_all function executed on global and all namespace DBs.
         """
         result = {}
-        Namespace.connect_all_dbs(dbs, db_name)
-        if len(dbs) == 1:
-            return dbs[0].get_all(db_name, _hash, *args, **kwargs)
+        if (len(dbs) > 1) : kwargs['blocking'] = False
         for db_conn in dbs:
+            db_conn.connect(db_name)
             # If there are multiple namespaces, _hash might not be 
             # present in all namespace, ignore if not present in a
             # specfic namespace.
-            ns_result = db_conn.get_all(db_name, _hash, blocking=False)
+            ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
             if ns_result is not None:
                 result.update(ns_result)
         return result

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,7 +552,8 @@ class Namespace:
         # If there are multiple namespaces, _hash might not be 
         # present in all namespace, ignore if not present in a
         # specfic namespace.
-        if len(dbs) > 1 : kwargs['blocking'] = False
+        if len(dbs) > 1: 
+            kwargs['blocking'] = False
         for db_conn in dbs:
             ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
             if ns_result is not None:

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -552,7 +552,7 @@ class Namespace:
         # If there are multiple namespaces, _hash might not be 
         # present in all namespace, ignore if not present in a
         # specfic namespace.
-        if (len(dbs) > 1) : kwargs['blocking'] = False
+        if len(dbs) > 1 : kwargs['blocking'] = False
         for db_conn in dbs:
             ns_result = db_conn.get_all(db_name, _hash, *args, **kwargs)
             if ns_result is not None:

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -7,7 +7,7 @@ import tests.mock_tables.dbconnector
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
-from sonic_ax_impl.mibs import Namespace 
+from sonic_ax_impl.mibs import Namespace
 
 class TestGetNextPDU(TestCase):
     @classmethod

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -7,7 +7,7 @@ import tests.mock_tables.dbconnector
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
-from sonic_ax_impl import mibs
+from sonic_ax_impl.mibs import Namespace 
 
 class TestGetNextPDU(TestCase):
     @classmethod
@@ -16,12 +16,12 @@ class TestGetNextPDU(TestCase):
         tests.mock_tables.dbconnector.load_database_config() 
 
     def test_init_sync_d_lag_tables(self):
-        db_conn = mibs.init_db()
+        db_conn = Namespace.init_namespace_dbs()
 
         lag_name_if_name_map, \
         if_name_lag_name_map, \
         oid_lag_name_map, \
-        lag_sai_map = mibs.init_sync_d_lag_tables(db_conn)
+        lag_sai_map = Namespace.init_namespace_sync_d_lag_tables(db_conn)
 
         self.assertTrue(b"PortChannel04" in lag_name_if_name_map)
         self.assertTrue(lag_name_if_name_map[b"PortChannel04"] == [b"Ethernet124"])


### PR DESCRIPTION
Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
To support namespaces, we added a Namespace class with functions to support getting data from all databases.
The Namespace dbs_get_all function , checks if the key exists in the database and does db connect before executing get_all.
Both of this operation causes additional time, which was causing agentx socket to disconnect.

**- How I did it**
- Remove the additional check that was added to see if the key exists before doing a get all.
- Remove db connect from dbs_get_all , as this was adding additional delay in dbs_get_all function, which is called during update_data. Instead, connect to all dbs during initialization, and connect to required dbs before invoking sync_d functions to ensure connection persists periodically.

**- How to verify it**
For single-asic platform and multi-asic, execute snmp queries to verify that the agentx socket does not disconnect and time issue is seen.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

