### PR TITLE
[201911] Fix interface counters in RFC1213

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -8,6 +8,7 @@ from sonic_ax_impl.mibs import Namespace
 from ax_interface.mib import MIBMeta, ValueType, MIBUpdater, MIBEntry, SubtreeMIBEntry, OverlayAdpaterMIBEntry, OidMIBEntry
 from ax_interface.encodings import ObjectIdentifier
 from ax_interface.util import mac_decimals, ip2tuple_v4
+from swsssdk.port_util import get_index_from_str
 
 @unique
 class DbTables(int, Enum):
@@ -168,6 +169,7 @@ class InterfacesUpdater(MIBUpdater):
         self.if_id_map = {}
         self.oid_sai_map = {}
         self.oid_name_map = {}
+        self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
     def reinit_data(self):
         """
@@ -191,9 +193,11 @@ class InterfacesUpdater(MIBUpdater):
         Update redis (caches config)
         Pulls the table references for each interface.
         """
-        self.if_counters = \
-            {sai_id: Namespace.dbs_get_all(self.db_conn, mibs.COUNTERS_DB, mibs.counter_table(sai_id), blocking=True)
-            for sai_id in self.if_id_map}
+        for sai_id_key in self.if_id_map:
+            namespace, sai_id = mibs.split_sai_id_key(sai_id_key)
+            if_idx = get_index_from_str(self.if_id_map[sai_id_key].decode())
+            self.if_counters[if_idx] = self.namespace_db_map[namespace].get_all(mibs.COUNTERS_DB, \
+                    mibs.counter_table(sai_id), blocking=True)
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \
@@ -254,12 +258,10 @@ class InterfacesUpdater(MIBUpdater):
         :param table_name: the redis table (either IntEnum or string literal) to query.
         :return: the counter for the respective sub_id/table.
         """
-        sai_id = self.oid_sai_map[oid]
-        # Enum.name or table_name = 'name_of_the_table'
         _table_name = bytes(getattr(table_name, 'name', table_name), 'utf-8')
 
         try:
-            counter_value = self.if_counters[sai_id][_table_name]
+            counter_value = self.if_counters[oid][_table_name]
             # truncate to 32-bit counter (database implements 64-bit counters)
             counter_value = int(counter_value) & 0x00000000ffffffff
             # done!

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -169,6 +169,7 @@ class InterfacesUpdater(MIBUpdater):
         self.if_id_map = {}
         self.oid_sai_map = {}
         self.oid_name_map = {}
+        # namespace : db connector
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
     def reinit_data(self):

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -169,7 +169,6 @@ class InterfacesUpdater(MIBUpdater):
         self.if_id_map = {}
         self.oid_sai_map = {}
         self.oid_name_map = {}
-        # namespace : db connector
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
     def reinit_data(self):

--- a/tests/namespace/test_interfaces.py
+++ b/tests/namespace/test_interfaces.py
@@ -22,8 +22,6 @@ from sonic_ax_impl import mibs
 class TestGetNextPDU(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.skipTest(cls, "TODO: Need to update corresponding MIB implementation \
-                in the Snmp Agent for multiple namespaces/multi-asic")
         tests.mock_tables.dbconnector.load_namespace_config()
         importlib.reload(rfc1213)
         cls.lut = MIBTable(rfc1213.InterfacesMIB)


### PR DESCRIPTION
Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In multi-asic platform, SAI OID is not unique for the whole device. It is unique for an asic and within a single namespace.
This PR is to fix InterfacesMIB rfc1213 implementation to make sure that interfaces counters is keyed based on interface index and not SAI OID.

**- How I did it**
In rfc1213 ; update code to use interface index as key in interface counter dict.
Run unit-test for namespace as well.

**- How to verify it**
Verified on multi-asic and single asic platform, to check interface counters are correct.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

