### PR TITLE
[Namespace]: Simplify sync_d functions to use higher order

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -556,8 +556,8 @@ class Namespace:
         
     @staticmethod
     def get_sync_d_from_all_namespace(per_namespace_func, dbs):
-        # return list of dictionaries retrieved from per namespace functions
-        # map of index:dict
+        # return merged tuple of dictionaries retrieved from per
+        # namespace functions.
         result_map = {}
         # list of return values
         result_list = []
@@ -570,7 +570,7 @@ class Namespace:
                     result_map[idx].update(ns_tuple[idx])
         for idx, ns_tuple_dict in result_map.items():
             result_list.append(ns_tuple_dict)
-        return(result_list)
+        return result_list
 
     @staticmethod
     def dbs_get_bridge_port_map(dbs, db_name):

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -554,82 +554,23 @@ class Namespace:
         else:
             return dbs[1:]
         
-
     @staticmethod
-    def init_namespace_sync_d_interface_tables(dbs):
-        if_name_map = {}
-        if_alias_map = {}
-        if_id_map = {}
-        oid_sai_map = {}
-        oid_name_map = {}
-
-        """
-        all_ns_db - will have db_conn to all namespace DBs and
-        global db. First db in the list is global db.
-        Ignore first global db to get interface tables if there
-        are multiple namespaces.
-        """
-        Namespace.connect_namespace_dbs(dbs)
+    def get_sync_d_from_all_namespace(per_namespace_func, dbs):
+        # return list of dictionaries retrieved from per namespace functions
+        # map of index:dict
+        result_map = {}
+        # list of return values
+        result_list = []
         for db_conn in Namespace.get_non_host_dbs(dbs):
-            if_name_map_ns, \
-            if_alias_map_ns, \
-            if_id_map_ns, \
-            oid_sai_map_ns, \
-            oid_name_map_ns = init_sync_d_interface_tables(db_conn)
-            if_name_map.update(if_name_map_ns)
-            if_alias_map.update(if_alias_map_ns)
-            if_id_map.update(if_id_map_ns)
-            oid_sai_map.update(oid_sai_map_ns)
-            oid_name_map.update(oid_name_map_ns)
-
-        return if_name_map, if_alias_map, if_id_map, oid_sai_map, oid_name_map
-
-    @staticmethod
-    def init_namespace_sync_d_lag_tables(dbs):
-
-        lag_name_if_name_map = {}
-        if_name_lag_name_map = {}
-        oid_lag_name_map = {}
-
-        """
-        all_ns_db - will have db_conn to all namespace DBs and
-        global db. First db in the list is global db.
-        Ignore first global db to get lag tables if
-        there are multiple namespaces.
-        """
-        Namespace.connect_namespace_dbs(dbs)
-        for db_conn in Namespace.get_non_host_dbs(dbs):
-            lag_name_if_name_map_ns, \
-            if_name_lag_name_map_ns, \
-            oid_lag_name_map_ns = init_sync_d_lag_tables(db_conn)
-            lag_name_if_name_map.update(lag_name_if_name_map_ns)
-            if_name_lag_name_map.update(if_name_lag_name_map_ns)
-            oid_lag_name_map.update(oid_lag_name_map_ns)
-
-        return lag_name_if_name_map, if_name_lag_name_map, oid_lag_name_map
-
-    @staticmethod
-    def init_namespace_sync_d_queue_tables(dbs):
-        port_queues_map = {}
-        queue_stat_map = {}
-        port_queue_list_map = {}
-
-        """
-        all_ns_db - will have db_conn to all namespace DBs and
-        global db. First db in the list is global db.
-        Ignore first global db to get queue tables if there
-        are multiple namespaces.
-        """
-        Namespace.connect_namespace_dbs(dbs)
-        for db_conn in Namespace.get_non_host_dbs(dbs):
-            port_queues_map_ns, \
-            queue_stat_map_ns, \
-            port_queue_list_map_ns = init_sync_d_queue_tables(db_conn)
-            port_queues_map.update(port_queues_map_ns)
-            queue_stat_map.update(queue_stat_map_ns)
-            port_queue_list_map.update(port_queue_list_map_ns)
-
-        return port_queues_map, queue_stat_map, port_queue_list_map
+            ns_tuple = per_namespace_func(db_conn)
+            for idx in range(len(ns_tuple)):
+                if idx not in result_map:
+                    result_map[idx] = ns_tuple[idx]
+                else:
+                    result_map[idx].update(ns_tuple[idx])
+        for idx, ns_tuple_dict in result_map.items():
+            result_list.append(ns_tuple_dict)
+        return(result_list)
 
     @staticmethod
     def dbs_get_bridge_port_map(dbs, db_name):

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -166,7 +166,7 @@ class LocPortUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.mgmt_oid_name_map, \
         self.mgmt_alias_map = mibs.init_mgmt_interface_tables(self.db_conn[0])
@@ -401,7 +401,7 @@ class LLDPRemTableUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.mgmt_oid_name_map, _ = mibs.init_mgmt_interface_tables(self.db_conn[0])
 
@@ -561,7 +561,7 @@ class LLDPRemManAddrUpdater(MIBUpdater):
         """
         Subclass reinit data routine.
         """
-        _, _, _, _, self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        _, _, _, _, self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.mgmt_oid_name_map, _ = mibs.init_mgmt_interface_tables(self.db_conn[0])
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -178,7 +178,7 @@ class InterfacesUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
         """
         db_conn - will have db_conn to all namespace DBs and
         global db. First db in the list is global db.
@@ -200,7 +200,7 @@ class InterfacesUpdater(MIBUpdater):
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \
-        self.oid_lag_name_map = Namespace.init_namespace_sync_d_lag_tables(self.db_conn)
+        self.oid_lag_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
 
         self.if_range = sorted(list(self.oid_sai_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -153,7 +153,7 @@ class PhysicalTableMIBUpdater(MIBUpdater):
 
         # update interface maps
         _, self.if_alias_map, _, _, _ = \
-            Namespace.init_namespace_sync_d_interface_tables(Namespace.init_namespace_dbs())
+            Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, Namespace.init_namespace_dbs())
 
         device_metadata = mibs.get_device_metadata(self.statedb[0])
         chassis_sub_id = (self.CHASSIS_ID, )

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -77,11 +77,11 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \
-        self.oid_lag_name_map = Namespace.init_namespace_sync_d_lag_tables(self.db_conn)
+        self.oid_lag_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
         """
         db_conn - will have db_conn to all namespace DBs and
         global db. First db in the list is global db.

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -41,7 +41,7 @@ class FdbUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.if_bpid_map = Namespace.dbs_get_bridge_port_map(self.db_conn, mibs.ASIC_DB)
         self.bvid_vlan_map.clear()

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -36,7 +36,7 @@ class PfcUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.update_data()
 
@@ -51,7 +51,7 @@ class PfcUpdater(MIBUpdater):
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \
-        self.oid_lag_name_map = Namespace.init_namespace_sync_d_lag_tables(self.db_conn)
+        self.oid_lag_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
 
         self.if_range = sorted(list(self.oid_sai_map.keys()) + list(self.oid_lag_name_map.keys()))
         self.if_range = [(i,) for i in self.if_range]

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -74,10 +74,10 @@ class QueueStatUpdater(MIBUpdater):
         self.if_alias_map, \
         self.if_id_map, \
         self.oid_sai_map, \
-        self.oid_name_map = Namespace.init_namespace_sync_d_interface_tables(self.db_conn)
+        self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)
 
         self.port_queues_map, self.queue_stat_map, self.port_queue_list_map = \
-            Namespace.init_namespace_sync_d_queue_tables(self.db_conn)
+            Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_queue_tables, self.db_conn)
 
         self.queue_type_map = Namespace.dbs_get_all(self.db_conn, mibs.COUNTERS_DB, "COUNTERS_QUEUE_TYPE_MAP", blocking=False)
 

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import tests.mock_tables.dbconnector
 from sonic_ax_impl.mibs import Namespace
+from sonic_ax_impl import mibs
 
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
@@ -20,7 +21,7 @@ class TestGetNextPDU(TestCase):
 
         lag_name_if_name_map, \
         if_name_lag_name_map, \
-        oid_lag_name_map = Namespace.init_namespace_sync_d_lag_tables(dbs)
+        oid_lag_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, dbs)
         #PortChannel in asic0 Namespace
         self.assertTrue(b"PortChannel01" in lag_name_if_name_map)
         self.assertTrue(b"Ethernet-BP0" in lag_name_if_name_map[b"PortChannel01"])

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -8,6 +8,7 @@ modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from sonic_ax_impl.mibs import Namespace
+from sonic_ax_impl import mibs
 
 class TestGetNextPDU(TestCase):
     @classmethod
@@ -20,7 +21,7 @@ class TestGetNextPDU(TestCase):
 
         lag_name_if_name_map, \
         if_name_lag_name_map, \
-        oid_lag_name_map = Namespace.init_namespace_sync_d_lag_tables(db_conn)
+        oid_lag_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, db_conn)
 
         self.assertTrue(b"PortChannel04" in lag_name_if_name_map)
         self.assertTrue(lag_name_if_name_map[b"PortChannel04"] == [b"Ethernet124"])


### PR DESCRIPTION
functions.

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Namespace class was added to support getting data from multiple namespaces.
This class includes some functions which get data from multiple namespaces and combine them.
This PR is to simplify the function of getting from separate functions and merge them.

**- How I did it**
Write a higher order function to invoke individual function to retrieve data from a single namespace.
The higher order function will retrieve the data and combine.

**- How to verify it**
No change in single and multi-asic snmp walk outputs.
Only implementation changes.
Make sure snmp walk outputs before change and after change are the same.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

