### PR TITLE
[LLDP]: Modify OID index of LLDPRemTableUpdater MIB

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -430,7 +430,7 @@ class LLDPRemTableUpdater(MIBUpdater):
             if not lldp_kvs:
                 continue
             try:
-                time_mark = int(lldp_kvs[b'lldp_rem_time_mark'])
+                time_mark = 0
                 remote_index = int(lldp_kvs[b'lldp_rem_index'])
                 self.if_range.append((time_mark,
                                       if_oid,

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -430,6 +430,11 @@ class LLDPRemTableUpdater(MIBUpdater):
             if not lldp_kvs:
                 continue
             try:
+                # OID index for this MIB consists of remote time mark, if_oid, remote_index.
+                # For multi-asic platform, it can happen that same interface index result 
+                # is seen in SNMP walk, with a different remote time mark.
+                # To avoid repeating the data of same interface index with different remote 
+                # time mark, remote time mark is made as 0 in the OID indexing.
                 time_mark = 0
                 remote_index = int(lldp_kvs[b'lldp_rem_index'])
                 self.if_range.append((time_mark,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
LLDPRemTableUpdater index in OID is a tuple of  (remote time mark, if index, remote device index).
```
For example: LLDP-MIB::lldpRemSysName.615.177.11 = STRING: remote_device_name
here , remote time mark is 615, interface index is 615, remote device index is 11.
```
 In case of multi-asic platform, when querying this MIB it can happen that same if index result is seen in SNMP walk, with a different remote time mark. 
```
For example: 
LLDP-MIB::lldpRemSysName.615.177.11 = STRING: remote_device_name
LLDP-MIB::lldpRemSysName.625.177.11 = STRING: remote_device_name
```
In the above walk, 177 interface index data appears twice.

**- How I did it**
To avoid showing same if index result in the  result, set remote time mark to 0, as this value is not significant, 

**- How to verify it**
Make sure the output of single asic platform shows the same result as before but with OID modified as: lldpRemSysName.0.if_index.remote_dev_id.
This will take effect in the entire LLDPRemTableUpdater table.

Make sure the output on mulit asic platform shows the result with unique interface index.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
