### PR TITLE
[pytest/coverage]: add coverage support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
-filterwarnings =
-    ignore::DeprecationWarning
 addopts = --cov=src --cov-report html --cov-report term --cov-report xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning
+addopts = --cov=src --cov-report html --cov-report term --cov-report xml

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ dependencies = [
 
 test_deps = [
     'mockredispy>=2.9.3',
-    'pytest>=3.0.5',
+    'pytest',
+    'pytest-cov',
 ]
 
 high_performance_deps = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add coverage for source code.

**- How I did it**

**- How to verify it**
```
----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                                                              Stmts   Miss  Cover
-------------------------------------------------------------------------------------
src/ax_interface/__init__.py                                          8      0   100%
src/ax_interface/agent.py                                            28     20    29%
src/ax_interface/constants.py                                        47      0   100%
src/ax_interface/encodings.py                                       136     12    91%
src/ax_interface/exceptions.py                                       26      7    73%
src/ax_interface/mib.py                                             250     56    78%
src/ax_interface/pdu.py                                             107     11    90%
src/ax_interface/pdu_implementations.py                             192     14    93%
src/ax_interface/protocol.py                                         71     54    24%
src/ax_interface/socket_io.py                                        91     76    16%
src/ax_interface/util.py                                             28      3    89%
src/sonic_ax_impl/__init__.py                                         5      0   100%
src/sonic_ax_impl/__main__.py                                        59     59     0%
src/sonic_ax_impl/lib/__init__.py                                     0      0   100%
src/sonic_ax_impl/lib/perseverantsocket.py                           34      6    82%
src/sonic_ax_impl/lib/quaggaclient.py                               110     13    88%
src/sonic_ax_impl/main.py                                            32     16    50%
src/sonic_ax_impl/mibs/__init__.py                                  289     23    92%
src/sonic_ax_impl/mibs/ieee802_1ab.py                               435     87    80%
src/sonic_ax_impl/mibs/ietf/__init__.py                               0      0   100%
src/sonic_ax_impl/mibs/ietf/rfc1213.py                              275     25    91%
src/sonic_ax_impl/mibs/ietf/rfc2737.py                              179     29    84%
src/sonic_ax_impl/mibs/ietf/rfc2863.py                              143     19    87%
src/sonic_ax_impl/mibs/ietf/rfc3433.py                              180     19    89%
src/sonic_ax_impl/mibs/ietf/rfc4292.py                               65      2    97%
src/sonic_ax_impl/mibs/ietf/rfc4363.py                               65     10    85%
src/sonic_ax_impl/mibs/vendor/__init__.py                            28      4    86%
src/sonic_ax_impl/mibs/vendor/cisco/__init__.py                       4      0   100%
src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py                          55     15    73%
src/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py      84     15    82%
src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py               147     44    70%
src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py             78      2    97%
src/sonic_ax_impl/mibs/vendor/dell/__init__.py                        1      0   100%
src/sonic_ax_impl/mibs/vendor/dell/force10.py                         9      0   100%
-------------------------------------------------------------------------------------
TOTAL                                                              3261    641    80%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

