### PR TITLE
Get port configuration from ConfigDB instead of AppDB

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -119,7 +119,7 @@ def if_entry_table(if_name):
     :param if_name: given interface to cast.
     :return: PORT_TABLE key.
     """
-    return b'PORT_TABLE:' + if_name
+    return b'PORT|' + if_name
 
 
 def lag_entry_table(lag_name):
@@ -270,7 +270,7 @@ def init_sync_d_interface_tables(db_conn):
     if_alias_map = dict()
 
     for if_name in if_name_map:
-        if_entry = db_conn.get_all(APPL_DB, if_entry_table(if_name), blocking=True)
+        if_entry = db_conn.get_all(CONFIG_DB, if_entry_table(if_name), blocking=True)
         if_alias_map[if_name] = if_entry.get(b'alias', if_name)
 
     logger.debug("Chassis name map:\n" + pprint.pformat(if_alias_map, indent=2))

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -121,7 +121,7 @@ def if_entry_table_app_db(if_name):
     """
     return b'PORT_TABLE:' + if_name
 
-def if_entry_table(if_name):
+def if_entry_table_config_db(if_name):
     """
     :param if_name: given interface to cast.
     :return: PORT key.
@@ -277,7 +277,7 @@ def init_sync_d_interface_tables(db_conn):
     if_alias_map = dict()
 
     for if_name in if_name_map:
-        if_entry = db_conn.get_all(CONFIG_DB, if_entry_table(if_name), blocking=True)
+        if_entry = db_conn.get_all(CONFIG_DB, if_entry_table_config_db(if_name), blocking=True)
         if_alias_map[if_name] = if_entry.get(b'alias', if_name)
 
     logger.debug("Chassis name map:\n" + pprint.pformat(if_alias_map, indent=2))

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -114,10 +114,17 @@ def lldp_entry_table(if_name):
     return b'LLDP_ENTRY_TABLE:' + if_name
 
 
-def if_entry_table(if_name):
+def if_entry_table_app_db(if_name):
     """
     :param if_name: given interface to cast.
     :return: PORT_TABLE key.
+    """
+    return b'PORT_TABLE:' + if_name
+
+def if_entry_table(if_name):
+    """
+    :param if_name: given interface to cast.
+    :return: PORT key.
     """
     return b'PORT|' + if_name
 

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -185,15 +185,11 @@ class LocPortUpdater(MIBUpdater):
 
     def _get_if_entry(self, if_name):
         if_table = ""
-
-        # Once PORT_TABLE will be moved to CONFIG DB
-        # we will get entry from CONFIG_DB for all cases
-        db = mibs.APPL_DB
+        db = mibs.CONFIG_DB
         if if_name in self.if_name_map:
             if_table = mibs.if_entry_table(if_name)
         elif if_name in self.mgmt_oid_name_map.values():
             if_table = mibs.mgmt_if_entry_table(if_name)
-            db = mibs.CONFIG_DB
         else:
             return None
 

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -187,7 +187,7 @@ class LocPortUpdater(MIBUpdater):
         if_table = ""
         db = mibs.CONFIG_DB
         if if_name in self.if_name_map:
-            if_table = mibs.if_entry_table(if_name)
+            if_table = mibs.if_entry_table_config_db(if_name)
         elif if_name in self.mgmt_oid_name_map.values():
             if_table = mibs.mgmt_if_entry_table(if_name)
         else:

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -352,7 +352,7 @@ class InterfacesUpdater(MIBUpdater):
             if_table = mibs.mgmt_if_entry_table(self.mgmt_oid_name_map[oid])
             db = mibs.CONFIG_DB
         elif oid in self.oid_name_map:
-            if_table = mibs.if_entry_table(self.oid_name_map[oid])
+            if_table = mibs.if_entry_table_config_db(self.oid_name_map[oid])
             db = mibs.CONFIG_DB
         else:
             return None

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -378,6 +378,26 @@ class InterfacesUpdater(MIBUpdater):
 
         return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
 
+    def _get_if_entry_app_db(self, sub_id):
+        """
+        :param oid: The 1-based sub-identifier query.
+        :return: the DB entry for the respective sub_id.
+        """
+        oid = self.get_oid(sub_id)
+        if not oid:
+            return
+
+        if_table = ""
+        db = mibs.APPL_DB
+        if oid in self.oid_name_map:
+            if_name = self.oid_name_map[oid]
+            if_table = mibs.if_entry_table_app_db(if_name)
+        else:
+            return None
+
+        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
+
+
     def _get_status(self, sub_id, key):
         """
         :param sub_id: The 1-based sub-identifier query.
@@ -397,8 +417,11 @@ class InterfacesUpdater(MIBUpdater):
         # Once PORT_TABLE will be moved to CONFIG DB
         # we will get rid of this if-else
         # and read oper status from STATE_DB
-        if self.get_oid(sub_id) in self.mgmt_oid_name_map and key == b"oper_status":
+        oid = self.get_oid(sub_id)
+        if oid in self.mgmt_oid_name_map and key == b"oper_status":
             entry = self._get_if_entry_state_db(sub_id)
+        elif oid in self.oid_name_map and key == b"oper_status":
+            entry = self._get_if_entry_app_db(sub_id)
         else:
             entry = self._get_if_entry(sub_id)
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -353,6 +353,7 @@ class InterfacesUpdater(MIBUpdater):
             db = mibs.CONFIG_DB
         elif oid in self.oid_name_map:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
+            db = mibs.CONFIG_DB
         else:
             return None
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -218,7 +218,7 @@ class InterfaceMIBUpdater(MIBUpdater):
             if_table = mibs.mgmt_if_entry_table(self.mgmt_oid_name_map[oid])
             db = mibs.CONFIG_DB
         elif oid in self.oid_name_map:
-            if_table = mibs.if_entry_table(self.oid_name_map[oid])
+            if_table = mibs.if_entry_table_config_db(self.oid_name_map[oid])
             db = mibs.CONFIG_DB
         else:
             return None

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -219,6 +219,7 @@ class InterfaceMIBUpdater(MIBUpdater):
             db = mibs.CONFIG_DB
         elif oid in self.oid_name_map:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
+            db = mibs.CONFIG_DB
         else:
             return None
 

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -473,12 +473,14 @@
   "PORT_TABLE:Ethernet0": {
     "description": "snowflake",
     "alias": "etp1",
-    "speed": 100000
+    "speed": 100000,
+    "oper_status": "down"
   },
   "PORT_TABLE:Ethernet4": {
     "description": "snowflake",
     "alias": "etp2",
-    "speed": 100000
+    "speed": 100000,
+    "oper_status": "up"
   },
   "PORT_TABLE:Ethernet8": {
     "description": "snowflake",

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -474,13 +474,13 @@
     "description": "snowflake",
     "alias": "etp1",
     "speed": 100000,
-    "oper_status": "down"
+    "oper_status": "up"
   },
   "PORT_TABLE:Ethernet4": {
     "description": "snowflake",
     "alias": "etp2",
     "speed": 100000,
-    "oper_status": "up"
+    "oper_status": "down"
   },
   "PORT_TABLE:Ethernet8": {
     "description": "snowflake",

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -1,2 +1,22 @@
 {
+  "PORT|Ethernet0": {
+    "description": "snowflake",
+    "alias": "etp1",
+    "speed": 100000
+  },
+  "PORT|Ethernet4": {
+    "description": "snowflake",
+    "alias": "etp2",
+    "speed": 100000
+  },
+  "PORT|Ethernet-BP0": {
+    "description": "snowflake",
+    "alias": "etp3",
+    "speed": 100000
+  },
+  "PORT|Ethernet-BP4": {
+    "description": "snowflake",
+    "alias": "etp4",
+    "speed": 100000
+  }
 }

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -51,7 +51,7 @@
   "PORT_TABLE:Ethernet-BP12": {
     "description": "snowflake",
     "alias": "etp8",
-    "speed": 1000 
+    "speed": 1000
   },
   "ROUTE_TABLE:0.0.0.0/0": {
     "ifname": "Ethernet8,Ethernet12",

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -1,2 +1,19 @@
 {
+  "PORT|Ethernet8": {
+    "description": "snowflake",
+    "alias": "etp5",
+    "speed": 100000
+  },
+  "PORT|Ethernet12": {
+    "speed": 1000,
+    "alias": "etp6"
+  },
+  "PORT|Ethernet-BP8": {
+    "alias": "etp7"
+  },
+  "PORT|Ethernet-BP12": {
+    "description": "snowflake",
+    "alias": "etp8",
+    "speed": 1000
+  }
 }

--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -1,2 +1,22 @@
 {
+  "PORT|Ethernet-BP16": {
+    "description": "backplane",
+    "alias": "etp9",
+    "speed": 100000
+  },
+  "PORT|Ethernet-BP20": {
+    "description": "backplane",
+    "alias": "etp10",
+    "speed": 100000
+  },
+  "PORT|Ethernet-BP24": {
+    "description": "backplane",
+    "alias": "etp11",
+    "speed": 100000
+  },
+  "PORT|Ethernet-BP28": {
+    "description": "backplane",
+    "alias": "etp12",
+    "speed": 100000
+  }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -2,12 +2,14 @@
   "PORT|Ethernet0": {
     "description": "snowflake",
     "alias": "etp1",
-    "speed": 100000
+    "speed": 100000,
+    "admin_status": "up"
   },
   "PORT|Ethernet4": {
     "description": "snowflake",
     "alias": "etp2",
-    "speed": 100000
+    "speed": 100000,
+    "admin_status": "up"
   },
   "PORT|Ethernet8": {
     "description": "snowflake",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -3,7 +3,7 @@
     "description": "snowflake",
     "alias": "etp1",
     "speed": 100000,
-    "admin_status": "up"
+    "admin_status": "down"
   },
   "PORT|Ethernet4": {
     "description": "snowflake",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1,4 +1,162 @@
 {
+  "PORT|Ethernet0": {
+    "description": "snowflake",
+    "alias": "etp1",
+    "speed": 100000
+  },
+  "PORT|Ethernet4": {
+    "description": "snowflake",
+    "alias": "etp2",
+    "speed": 100000
+  },
+  "PORT|Ethernet8": {
+    "description": "snowflake",
+    "alias": "etp3",
+    "speed": 100000
+  },
+  "PORT|Ethernet12": {
+    "description": "snowflake",
+    "alias": "etp4",
+    "speed": 100000
+  },
+  "PORT|Ethernet16": {
+    "description": "snowflake",
+    "alias": "etp5",
+    "speed": 100000
+  },
+  "PORT|Ethernet20": {
+    "description": "snowflake",
+    "alias": "etp6",
+    "speed": 100000
+  },
+  "PORT|Ethernet24": {
+    "description": "snowflake",
+    "alias": "etp7",
+    "speed": 100000
+  },
+  "PORT|Ethernet28": {
+    "description": "snowflake",
+    "alias": "etp8",
+    "speed": 100000
+  },
+  "PORT|Ethernet32": {
+    "description": "snowflake",
+    "alias": "etp9",
+    "speed": 100000
+  },
+  "PORT|Ethernet36": {
+    "description": "snowflake",
+    "alias": "etp10",
+    "speed": 100000
+  },
+  "PORT|Ethernet40": {
+    "description": "snowflake",
+    "alias": "etp11",
+    "speed": 100000
+  },
+  "PORT|Ethernet44": {
+    "description": "snowflake",
+    "alias": "etp12",
+    "speed": 100000
+  },
+  "PORT|Ethernet48": {
+    "description": "snowflake",
+    "alias": "etp13",
+    "speed": 100000
+  },
+  "PORT|Ethernet52": {
+    "description": "snowflake",
+    "alias": "etp14",
+    "speed": 100000
+  },
+  "PORT|Ethernet56": {
+    "description": "snowflake",
+    "alias": "etp15",
+    "speed": 100000
+  },
+  "PORT|Ethernet60": {
+    "description": "snowflake",
+    "alias": "etp16",
+    "speed": 100000
+  },
+  "PORT|Ethernet64": {
+    "description": "snowflake",
+    "alias": "etp17",
+    "speed": 100000
+  },
+  "PORT|Ethernet68": {
+    "description": "snowflake",
+    "alias": "etp18",
+    "speed": 100000
+  },
+  "PORT|Ethernet72": {
+    "description": "snowflake",
+    "alias": "etp19",
+    "speed": 100000
+  },
+  "PORT|Ethernet76": {
+    "description": "snowflake",
+    "alias": "etp20",
+    "speed": 100000
+  },
+  "PORT|Ethernet80": {
+    "description": "snowflake",
+    "alias": "etp21",
+    "speed": 100000
+  },
+  "PORT|Ethernet84": {
+    "description": "snowflake",
+    "alias": "etp22",
+    "speed": 100000
+  },
+  "PORT|Ethernet88": {
+    "description": "snowflake",
+    "alias": "etp23",
+    "speed": 100000
+  },
+  "PORT|Ethernet92": {
+    "description": "snowflake",
+    "alias": "etp24",
+    "speed": 100000
+  },
+  "PORT|Ethernet96": {
+    "description": "snowflake",
+    "alias": "etp25",
+    "speed": 100000
+  },
+  "PORT|Ethernet100": {
+    "description": "snowflake",
+    "alias": "etp26",
+    "speed": 100000
+  },
+  "PORT|Ethernet104": {
+    "description": "snowflake",
+    "alias": "etp27",
+    "speed": 100000
+  },
+  "PORT|Ethernet108": {
+    "description": "snowflake",
+    "alias": "etp28",
+    "speed": 100000
+  },
+  "PORT|Ethernet112": {
+    "description": "snowflake",
+    "alias": "etp29",
+    "speed": 100000
+  },
+  "PORT|Ethernet116": {
+    "speed": 1000,
+    "alias": "etp30"
+  },
+  "PORT|Ethernet120": {
+    "description": "snowflake",
+    "alias": "et31"
+  },
+  "PORT|Ethernet124": {
+    "description": "snowflake",
+    "alias": "etp32",
+    "speed": 100000
+  },
   "MGMT_PORT|eth0": {
     "description": "snowflake",
     "speed": 1000

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -248,7 +248,34 @@ class TestGetNextPDU(TestCase):
 
 
     def test_if_admin_status(self):
-        pass
+        """
+        For front panel port admin status
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 0))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        response = get_pdu.make_response(self.lut)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 1))))
+        self.assertEqual(value0.data, 2) # down
+
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 1))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        response = get_pdu.make_response(self.lut)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 5))))
+        self.assertEqual(value0.data, 1) # up
 
     def test_mgmt_iface_description(self):
         pass

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -277,8 +277,22 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 5))))
         self.assertEqual(value0.data, 1) # up
 
-    def test_mgmt_iface_description(self):
-        pass
+    def test_if_description(self):
+        """
+        Test mgmt port description (which is simply an alias)
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 1))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        response = get_pdu.make_response(self.lut)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 1))))
+        self.assertEqual(str(value0.data), 'etp1')
 
     def test_if_type_portchannel(self):
         """

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -216,6 +216,43 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 3, 5))))
         self.assertEqual(value0.data, 6)
 
+    def test_if_oper_status(self):
+        """
+        For front panel port admin status
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 0))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        response = get_pdu.make_response(self.lut)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 1))))
+        self.assertEqual(value0.data, 2) # down
+
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 1))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        response = get_pdu.make_response(self.lut)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 5))))
+        self.assertEqual(value0.data, 1) # up
+
+
+    def test_if_admin_status(self):
+        pass
+
+    def test_mgmt_iface_description(self):
+        pass
+
     def test_if_type_portchannel(self):
         """
         For portchannel the type shpuld be 161

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -218,7 +218,7 @@ class TestGetNextPDU(TestCase):
 
     def test_if_oper_status(self):
         """
-        For front panel port admin status
+        For front panel port oper status
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 0))
         get_pdu = GetNextPDU(
@@ -279,7 +279,7 @@ class TestGetNextPDU(TestCase):
 
     def test_if_description(self):
         """
-        Test mgmt port description (which is simply an alias)
+        Test front panel port description (which is simply an alias)
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 1))
         get_pdu = GetPDU(

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -231,7 +231,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 1))))
-        self.assertEqual(value0.data, 2) # down
+        self.assertEqual(value0.data, 1) # up
 
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 1))
         get_pdu = GetNextPDU(
@@ -244,7 +244,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 5))))
-        self.assertEqual(value0.data, 1) # up
+        self.assertEqual(value0.data, 2) # down
 
 
     def test_if_admin_status(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Due to history issue, the configuration of port are moved from AppDB to ConfigDB, and the data in AppDB is just for backward-compatible. We need to migrate the snmpagent to access ConfigDB for port configuration such as admin_status/alias etc. However, the oper_status is still in AppDB.

Add test cases for InterfaceMIB.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

