### PR TITLE
[setup.py] Add 'wheel' package to 'setup_requires' list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ high_performance_deps = [
 setup(
     name='asyncsnmp',
     install_requires=dependencies,
-    setup_requires=["pytest-runner"],
+    setup_requires= [
+        'pytest-runner',
+        'wheel'
+    ],
     tests_require=test_deps,
     version='2.1.0',
     packages=find_packages('src'),


### PR DESCRIPTION
Add 'wheel' to the list of packages required for building the package. This way it will be implicitly installed at build time, preventing the need to intstall the 'wheel' package explicitly in our build environment.