### PR TITLE
[ciscoSwitchQosMIB]: Remove invocation of update_data function in reinit_data

### DIFF
--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -87,8 +87,6 @@ class QueueStatUpdater(MIBUpdater):
         for db_conn in Namespace.get_non_host_dbs(self.db_conn):
             self.queue_type_map[db_conn.namespace] = db_conn.get_all(mibs.COUNTERS_DB, "COUNTERS_QUEUE_TYPE_MAP", blocking=False)
  
-        self.update_data()
-
     def update_data(self):
         """
         Update redis (caches config)


### PR DESCRIPTION
[ciscoSwitchQosMIB]: Remove invocation of update_data function in reinit_data
function. udpate_data and reinit_data will be invoked by periodic
events. update_data need not be invoked by reinit_data again.
Additional invocation of update_data can cause increase in running time
on multi-asic platform causing Agentx socket connection to break.

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed invocation of update_data function in reinit_data function. 
udpate_data and reinit_data will be invoked by periodic events. 
update_data need not be invoked by reinit_data again.
Additional invocation of update_data can cause increase in running time on multi-asic platform causing Agentx socket connection to break.

**- How I did it**
Remove update_data call in reinit_data().

**- How to verify it**
Verified the output of QosMIB  1.3.6.1.4.1.9.9.580.1.5.5.1.4 on multi-asic platform.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

