### PR TITLE
[LLDP]: Update init_db to load global database config

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -184,7 +184,7 @@ def init_db():
     SonicDBConfig.load_sonic_global_db_config()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
-    db_conn = SonicV2Connector(**redis_kwargs)
+    db_conn = SonicV2Connector(use_unix_socket_path=True)
 
     return db_conn
 

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -181,9 +181,10 @@ def init_db():
     Connects to DB
     :return: db_conn
     """
+    SonicDBConfig.load_sonic_global_db_config()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
-    db_conn = SonicV2Connector(**redis_kwargs)
+    db_conn = SonicV2Connector()
 
     return db_conn
 

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -184,7 +184,7 @@ def init_db():
     SonicDBConfig.load_sonic_global_db_config()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
-    db_conn = SonicV2Connector()
+    db_conn = SonicV2Connector(**redis_kwargs)
 
     return db_conn
 

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -184,7 +184,7 @@ def init_db():
     SonicDBConfig.load_sonic_global_db_config()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
-    db_conn = SonicV2Connector(use_unix_socket_path=True)
+    db_conn = SonicV2Connector(**redis_kwargs)
 
     return db_conn
 

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -27,6 +27,15 @@
     "lldp_rem_port_id": "Ethernet2",
     "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
   },
+  "LLDP_LOC_CHASSIS": {
+    "lldp_loc_chassis_id_subtype": "5",
+    "lldp_loc_chassis_id": "00:11:22:AB:CD:EF",
+    "lldp_loc_sys_name": "SONiC",
+    "lldp_loc_sys_desc": "Gotta go Fast!",
+    "lldp_loc_sys_cap_enabled": "28 00",
+    "lldp_loc_sys_cap_supported": "28 00",
+    "lldp_loc_man_addr": "10.224.25.36,fe80::ce37:abff:feec:de9c"
+  },
   "PORT_TABLE:Ethernet0": {
     "description": "snowflake",
     "alias": "etp1",

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -34,7 +34,7 @@
     "lldp_loc_sys_desc": "Gotta go Fast!",
     "lldp_loc_sys_cap_enabled": "28 00",
     "lldp_loc_sys_cap_supported": "28 00",
-    "lldp_loc_man_addr": "10.224.25.26,fe80::ce37:abff:feec:de9c"
+    "lldp_loc_man_addr": "10.224.25.36,fe80::ce37:abff:feec:de9c"
   },
   "PORT_TABLE:Ethernet8": {
     "description": "snowflake",

--- a/tests/mock_tables/asic2/appl_db.json
+++ b/tests/mock_tables/asic2/appl_db.json
@@ -6,7 +6,7 @@
     "lldp_loc_sys_desc": "Gotta go Fast!",
     "lldp_loc_sys_cap_enabled": "28 00",
     "lldp_loc_sys_cap_supported": "28 00",
-    "lldp_loc_man_addr": "10.224.25.26,fe80::ce37:abff:feec:de9c"
+    "lldp_loc_man_addr": "10.224.25.36,fe80::ce37:abff:feec:de9c"
   },
   "PORT_TABLE:Ethernet-BP16": {
     "description": "backplane",

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -46,7 +46,7 @@ def connect_SonicV2Connector(self, db_name, retry_on=True):
     # In case of multiple namespaces, namespace string passed to
     # SonicV2Connector will specify the namespace or can be empty.
     # Empty namespace represents global or host namespace.
-    if len(ns_list) > 1 and self.namespace == "":
+    if len(ns_list) > 1 and (self.namespace == "" or self.namespace == None):
         self.dbintf.redis_kwargs['namespace'] = "global_db"
     else:
         self.dbintf.redis_kwargs['namespace'] = self.namespace

--- a/tests/mock_tables/global_db/appl_db.json
+++ b/tests/mock_tables/global_db/appl_db.json
@@ -20,6 +20,6 @@
     "lldp_loc_sys_desc": "Gotta go Fast!",
     "lldp_loc_sys_cap_enabled": "28 00",
     "lldp_loc_sys_cap_supported": "28 00",
-    "lldp_loc_man_addr": "10.224.25.26,fe80::ce37:abff:feec:de9c"
+    "lldp_loc_man_addr": "10.224.25.36,fe80::ce37:abff:feec:de9c"
   }
 }

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -118,6 +118,7 @@ class TestLLDPMIB(TestCase):
 
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(13, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 8, 1, 3, 1, 4, 10, 224, 25, 36))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 5)
 

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -97,6 +97,7 @@ class TestLLDPMIB(TestCase):
 
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(13, 0, 1, 0, (1, 0, 8802, 1, 1, 2, 1, 3, 8, 1, 3, 1, 4, 10, 224, 25, 26))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 5)
 


### PR DESCRIPTION
[LLDP]: Update init_db to load global database config 
before initializing SonicV2Connector class.
LLDPLocManAddrUpdater requires information from host database hence uses init_db() to initialize the host db.
For unit-testing multi-asic code path, there are mock db files provided for global_db and namespace specific dbs.
As init_db did not load global database config, unit-test mock db was not loading global_db database files for LLDPLocManAddrUpdater unit-testing. Fixed this by loading global database config in init_db function.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
As init_db did not load global database config, unit-test mock db was not loading global_db database files for LLDPLocManAddrUpdater unit-testing. Fixed this by loading global database config in init_db function.

**- How I did it**
- Load global database config in init_db()
- unit-test:  Load mock db files from "global_db" director for multi-asic platform if namespace is empty or None.

**- How to verify it**
Run unit-test test_subtype_lldp_loc_man_addr_table and make sure that for multi-asic platform, mock_tables/global_db/appl_db.json file is loaded and mock_tables/appl_db.json file is loaded for single-asic platform unit-test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

