### PR TITLE
[mibs] b'VLAN_TABLE:' -> 'VLAN_TABLE'

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -156,7 +156,7 @@ def vlan_entry_table(if_name):
     :param if_name: given interface to cast.
     :return: VLAN_TABLE key.
     """
-    return b'VLAN_TABLE:' + if_name
+    return 'VLAN_TABLE:' + if_name
 
 
 def lag_entry_table(lag_name):


### PR DESCRIPTION
Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a missed bytes to string conversion.

**- How I did it**
Remove "b"

**- How to verify it**
Add a L3 VLAN interface and query SNMP RFC1213 MIB.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

