### PR TITLE
[snmpagent] Fix hardcoded qsfp lane count by reading sensor status from DB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/physical_entity_sub_oid_generator.py
+++ b/src/sonic_ax_impl/mibs/ietf/physical_entity_sub_oid_generator.py
@@ -80,24 +80,6 @@ SENSOR_TYPE_PORT_TX_BIAS = 4 * SENSOR_TYPE_MULTIPLE
 CHASSIS_SUB_ID = 1
 CHASSIS_MGMT_SUB_ID = MODULE_TYPE_MGMT
 
-# This is used in both rfc2737 and rfc3433
-XCVR_SENSOR_PART_ID_MAP = {
-    "temperature":  SENSOR_TYPE_TEMP,
-    "tx1power":     SENSOR_TYPE_PORT_TX_POWER + 1,
-    "tx2power":     SENSOR_TYPE_PORT_TX_POWER + 2,
-    "tx3power":     SENSOR_TYPE_PORT_TX_POWER + 3,
-    "tx4power":     SENSOR_TYPE_PORT_TX_POWER + 4,
-    "rx1power":     SENSOR_TYPE_PORT_RX_POWER + 1,
-    "rx2power":     SENSOR_TYPE_PORT_RX_POWER + 2,
-    "rx3power":     SENSOR_TYPE_PORT_RX_POWER + 3,
-    "rx4power":     SENSOR_TYPE_PORT_RX_POWER + 4,
-    "tx1bias":      SENSOR_TYPE_PORT_TX_BIAS + 1,
-    "tx2bias":      SENSOR_TYPE_PORT_TX_BIAS + 2,
-    "tx3bias":      SENSOR_TYPE_PORT_TX_BIAS + 3,
-    "tx4bias":      SENSOR_TYPE_PORT_TX_BIAS + 4,
-    "voltage":      SENSOR_TYPE_VOLTAGE,
-}
-
 PSU_SENSOR_PART_ID_MAP = {
     'temperature': SENSOR_TYPE_TEMP,
     'power': SENSOR_TYPE_POWER,
@@ -175,14 +157,14 @@ def get_transceiver_sub_id(ifindex):
     """
     return (MODULE_TYPE_PORT + ifindex * PORT_IFINDEX_MULTIPLE, )
 
-def get_transceiver_sensor_sub_id(ifindex, sensor):
+def get_transceiver_sensor_sub_id(ifindex, offset):
     """
     Returns sub OID for transceiver sensor. Sub OID is calculated as folows:
-    sub OID = transceiver_oid + XCVR_SENSOR_PART_ID_MAP[sensor]
+    sub OID = transceiver_oid + offset
     :param ifindex: interface index
-    :param sensor: sensor key
+    :param offset: sensor OID offset
     :return: sub OID = {{index}} * 1000 + {{lane}} * 10 + sensor id
     """
 
     transceiver_oid, = get_transceiver_sub_id(ifindex)
-    return (transceiver_oid + XCVR_SENSOR_PART_ID_MAP[sensor],)
+    return (transceiver_oid + offset,)

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -299,7 +299,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
             if not transceiver_dom_entry_data:
                 continue
 
-            sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry)
+            sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry_data)
             for sensor_data in sensor_data_list:
                 raw_sensor_value = sensor_data.get_raw_value()
                 sensor = sensor_data.sensor_interface

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -11,6 +11,13 @@ from sonic_ax_impl import mibs
 from sonic_ax_impl.mibs import Namespace
 
 from .physical_entity_sub_oid_generator import get_transceiver_sensor_sub_id
+from .transceiver_sensor_data import TransceiverSensorData
+from .transceiver_sensor_data import TransceiverTempSensorData
+from .transceiver_sensor_data import TransceiverVoltageSensorData
+from .transceiver_sensor_data import TransceiverRxPowerSensorData
+from .transceiver_sensor_data import TransceiverTxPowerSensorData
+from .transceiver_sensor_data import TransceiverTxBiasSensorData
+
 
 @unique
 class EntitySensorDataType(int, Enum):
@@ -208,34 +215,13 @@ class XcvrTxPowerSensor(SensorInterface):
     CONVERTER = Converters.CONV_dBm_mW
 
 
-# mapping between DB key and Sensor object
-TRANSCEIVER_SENSOR_MAP = {
-    "temperature": XcvrTempSensor,
-    "voltage":     XcvrVoltageSensor,
-    "rx1power":    XcvrRxPowerSensor,
-    "rx2power":    XcvrRxPowerSensor,
-    "rx3power":    XcvrRxPowerSensor,
-    "rx4power":    XcvrRxPowerSensor,
-    "tx1bias":     XcvrTxBiasSensor,
-    "tx2bias":     XcvrTxBiasSensor,
-    "tx3bias":     XcvrTxBiasSensor,
-    "tx4bias":     XcvrTxBiasSensor,
-    "tx1power":    XcvrTxPowerSensor,
-    "tx2power":    XcvrTxPowerSensor,
-    "tx3power":    XcvrTxPowerSensor,
-    "tx4power":    XcvrTxPowerSensor,
-}
-
-
-def get_transceiver_sensor(sensor_key):
-    """
-    Gets transceiver sensor object
-    :param sensor_key: Sensor key from XcvrDomDB
-    :param ifindex: Interface index associated with transceiver
-    :return: Sensor object.
-    """
-
-    return TRANSCEIVER_SENSOR_MAP[sensor_key]
+TransceiverSensorData.bind_sensor_interface({
+    TransceiverTempSensorData:    XcvrTempSensor,
+    TransceiverVoltageSensorData: XcvrVoltageSensor,
+    TransceiverRxPowerSensorData: XcvrRxPowerSensor,
+    TransceiverTxPowerSensorData: XcvrTxPowerSensor,
+    TransceiverTxBiasSensorData:  XcvrTxBiasSensor
+})
 
 
 class PhysicalSensorTableMIBUpdater(MIBUpdater):
@@ -313,14 +299,11 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
             if not transceiver_dom_entry_data:
                 continue
 
-            for sensor_key in transceiver_dom_entry_data:
-                if sensor_key not in TRANSCEIVER_SENSOR_MAP:
-                    continue
-
-                raw_sensor_value = transceiver_dom_entry_data.get(sensor_key)
-
-                sensor = get_transceiver_sensor(sensor_key)
-                sub_id = get_transceiver_sensor_sub_id(ifindex, sensor_key)
+            sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry)
+            for sensor_data in sensor_data_list:
+                raw_sensor_value = sensor_data.get_raw_value()
+                sensor = sensor_data.sensor_interface
+                sub_id = get_transceiver_sensor_sub_id(ifindex, sensor_data.get_oid_offset())
 
                 try:
                     mib_values = sensor.mib_values(raw_sensor_value)

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -12,11 +12,6 @@ from sonic_ax_impl.mibs import Namespace
 
 from .physical_entity_sub_oid_generator import get_transceiver_sensor_sub_id
 from .transceiver_sensor_data import TransceiverSensorData
-from .transceiver_sensor_data import TransceiverTempSensorData
-from .transceiver_sensor_data import TransceiverVoltageSensorData
-from .transceiver_sensor_data import TransceiverRxPowerSensorData
-from .transceiver_sensor_data import TransceiverTxPowerSensorData
-from .transceiver_sensor_data import TransceiverTxBiasSensorData
 
 
 @unique
@@ -216,11 +211,11 @@ class XcvrTxPowerSensor(SensorInterface):
 
 
 TransceiverSensorData.bind_sensor_interface({
-    TransceiverTempSensorData:    XcvrTempSensor,
-    TransceiverVoltageSensorData: XcvrVoltageSensor,
-    TransceiverRxPowerSensorData: XcvrRxPowerSensor,
-    TransceiverTxPowerSensorData: XcvrTxPowerSensor,
-    TransceiverTxBiasSensorData:  XcvrTxBiasSensor
+    'temperature': XcvrTempSensor,
+    'voltage'    : XcvrVoltageSensor,
+    'rxpower'    : XcvrRxPowerSensor,
+    'txpower'    : XcvrTxPowerSensor,
+    'txbias'     : XcvrTxBiasSensor
 })
 
 
@@ -302,7 +297,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
             sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry_data)
             for sensor_data in sensor_data_list:
                 raw_sensor_value = sensor_data.get_raw_value()
-                sensor = sensor_data.sensor_interface
+                sensor = sensor_data.get_sensor_interface()
                 sub_id = get_transceiver_sensor_sub_id(ifindex, sensor_data.get_oid_offset())
 
                 try:

--- a/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
+++ b/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
@@ -1,0 +1,212 @@
+import re
+
+from .physical_entity_sub_oid_generator import SENSOR_TYPE_TEMP
+from .physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_POWER
+from .physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_RX_POWER
+from .physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_BIAS
+from .physical_entity_sub_oid_generator import SENSOR_TYPE_VOLTAGE
+
+
+def transceiver_sensor_data():
+    """
+    Decorator for auto registering transceiver sensor data type
+    """
+    def wrapper(object_type):
+        TransceiverSensorData.register(object_type)
+        return object_type
+
+    return wrapper
+
+
+class TransceiverSensorData:
+    """
+    Base transceiver sensor data class. Responsible for:
+        1. Manage concrete sensor data class
+        2. Create concrete sensor data instances
+        3. Provide common logic for concrete sensor data class
+    """
+    concrete_type_list = []
+    sensor_interface = None
+
+    def __init__(self, key, value, match_result):
+        self._key = key
+        self._value = value
+        self._match_result = match_result
+
+    @classmethod
+    def create_sensor_data(cls, sensor_data_dict):
+        """
+        Create sensor data instances according to the sensor data got from redis
+        :param sensor_data_dict: sensor data got from redis
+        :return: A sorted sensor data instance list
+        """
+        sensor_data_list = []
+        for name, value in sensor_data_dict.items():
+            for concrete_type in cls.concrete_type_list:
+                match_result = re.match(concrete_type.get_pattern(), name)
+                if match_result:
+                    sensor_data = concrete_type(name, value, match_result)
+                    sensor_data_list.append(sensor_data)
+        return sensor_data_list
+
+    @classmethod
+    def sort_sensor_data(cls, sensor_data_list):
+        return sorted(sensor_data_list, key=lambda x: x.get_sort_factor())
+
+    @classmethod
+    def register(cls, concrete_type):
+        """
+        Register concrete sensor data type
+        :param concrete_type: concrete sensor data class
+        :return:
+        """
+        cls.concrete_type_list.append(concrete_type)
+
+    @classmethod
+    def bind_sensor_interface(cls, sensor_interface_dict):
+        for concrete_type in cls.concrete_type_list:
+            if concrete_type in sensor_interface_dict:
+                concrete_type.sensor_interface = sensor_interface_dict[concrete_type]
+
+    def get_key(self):
+        """
+        Get the redis key of this sensor
+        """
+        return self._key
+
+    def get_raw_value(self):
+        """
+        Get raw redis value of this sensor
+        """
+        return self._value
+
+    def get_name(self):
+        """
+        Get the name of this sensor. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+    def get_sort_factor(self):
+        """
+        Get sort factor for this sensor. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+    def get_lane_number(self):
+        """
+        Get lane number of this sensor. For example, some transceivers have more than one rx power sensor, the sub index
+        of rx1power is 1, the sub index of rx2power is 2.
+        """
+        return int(self._match_result.group(1))
+
+    def get_oid_offset(self):
+        """
+        Get OID offset of this sensor.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_pattern(cls):
+        """
+        Return regular expression pattern for matching the sensor name. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+
+@transceiver_sensor_data()
+class TransceiverTempSensorData(TransceiverSensorData):
+    SORT_FACTOR = 0
+
+    @classmethod
+    def get_pattern(cls):
+        return 'temperature'
+
+    def get_name(self):
+        return 'Temperature'
+
+    def get_sort_factor(self):
+        return TransceiverTempSensorData.SORT_FACTOR
+
+    def get_lane_number(self):
+        return 0
+
+    def get_oid_offset(self):
+        return SENSOR_TYPE_TEMP
+
+
+@transceiver_sensor_data()
+class TransceiverVoltageSensorData(TransceiverSensorData):
+    SORT_FACTOR = 9000
+
+    @classmethod
+    def get_pattern(cls):
+        return 'voltage'
+
+    def get_name(self):
+        return 'Voltage'
+
+    def get_sort_factor(self):
+        return TransceiverVoltageSensorData.SORT_FACTOR
+
+    def get_lane_number(self):
+        return 0
+
+    def get_oid_offset(self):
+        return SENSOR_TYPE_VOLTAGE
+
+
+@transceiver_sensor_data()
+class TransceiverRxPowerSensorData(TransceiverSensorData):
+    SORT_FACTOR = 2000
+
+    @classmethod
+    def get_pattern(cls):
+        return 'rx(\d+)power'
+
+    def get_name(self):
+        return 'RX Power'
+
+    def get_sort_factor(self):
+        return TransceiverRxPowerSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return SENSOR_TYPE_PORT_RX_POWER + self.get_lane_number()
+
+
+@transceiver_sensor_data()
+class TransceiverTxPowerSensorData(TransceiverSensorData):
+    SORT_FACTOR = 1000
+
+    @classmethod
+    def get_pattern(cls):
+        return 'tx(\d+)power'
+
+    def get_name(self):
+        return 'TX Power'
+
+    def get_sort_factor(self):
+        return TransceiverTxPowerSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return SENSOR_TYPE_PORT_TX_POWER + self.get_lane_number()
+
+
+@transceiver_sensor_data()
+class TransceiverTxBiasSensorData(TransceiverSensorData):
+    SORT_FACTOR = 3000
+
+    @classmethod
+    def get_pattern(cls):
+        return 'tx(\d+)bias'
+
+    def get_name(self):
+        return 'TX Bias'
+
+    def get_sort_factor(self):
+        return TransceiverTxBiasSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return SENSOR_TYPE_PORT_TX_BIAS + self.get_lane_number()

--- a/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
+++ b/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
@@ -47,6 +47,7 @@ class TransceiverSensorData:
                 if match_result:
                     sensor_data = concrete_type(name, value, match_result)
                     sensor_data_list.append(sensor_data)
+                    break
         return sensor_data_list
 
     @classmethod

--- a/tests/namespace/test_sensor.py
+++ b/tests/namespace/test_sensor.py
@@ -17,6 +17,11 @@ from ax_interface import ValueType
 from ax_interface.encodings import ObjectIdentifier
 from ax_interface.constants import PduTypes
 from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_transceiver_sub_id, get_transceiver_sensor_sub_id
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_TEMP
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_VOLTAGE
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_RX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_BIAS
 from sonic_ax_impl.mibs.ietf import rfc3433
 from sonic_ax_impl.main import SonicMIB
 
@@ -80,7 +85,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'temperature')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_TEMP)[0], expected_values)
 
 
     def test_getpdu_xcvr_temperature_sensor_asic1(self):
@@ -96,7 +101,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX_ASIC1, 'temperature')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX_ASIC1, SENSOR_TYPE_TEMP)[0], expected_values)
 
     def test_getpdu_xcvr_voltage_sensor(self):
         """
@@ -111,7 +116,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'voltage')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_VOLTAGE)[0], expected_values)
 
 
     def test_getpdu_xcvr_voltage_sensor_asic1(self):
@@ -127,7 +132,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX_ASIC1, 'voltage')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX_ASIC1, SENSOR_TYPE_VOLTAGE)[0], expected_values)
 
     def test_getpdu_xcvr_rx_power_sensor_minus_infinity(self):
         """
@@ -143,7 +148,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'rx1power')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 1 + SENSOR_TYPE_PORT_RX_POWER)[0], expected_values)
 
     def test_getpdu_xcvr_rx_power_sensor(self):
         """
@@ -160,8 +165,7 @@ class TestSonicMIB(TestCase):
 
         # test for each channel except first, we already test above
         for channel in (2, 3, 4):
-            sensor = 'rx{}power'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_RX_POWER + channel)[0], expected_values)
 
     def test_getpdu_xcvr_tx_power_sensor(self):
         """
@@ -178,8 +182,7 @@ class TestSonicMIB(TestCase):
 
         # test for each channel except first, we already test above
         for channel in (1, 2, 3, 4):
-            sensor = 'tx{}power'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_POWER + channel)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor_unknown(self):
         """
@@ -195,7 +198,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.UNAVAILABLE
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'tx1bias')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 1 + SENSOR_TYPE_PORT_TX_BIAS)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor_overflow(self):
         """
@@ -211,7 +214,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'tx3bias')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 3 + SENSOR_TYPE_PORT_TX_BIAS)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor(self):
         """
@@ -228,6 +231,5 @@ class TestSonicMIB(TestCase):
 
         # test for each channel
         for channel in (2, 4):
-            sensor = 'tx{}bias'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_BIAS + channel)[0], expected_values)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,6 +16,11 @@ from ax_interface import ValueType
 from ax_interface.encodings import ObjectIdentifier
 from ax_interface.constants import PduTypes
 from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_transceiver_sub_id, get_transceiver_sensor_sub_id
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_TEMP
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_VOLTAGE
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_RX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_BIAS
 from sonic_ax_impl.mibs.ietf import rfc3433
 from sonic_ax_impl.main import SonicMIB
 
@@ -76,7 +81,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'temperature')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_TEMP)[0], expected_values)
 
     def test_getpdu_xcvr_voltage_sensor(self):
         """
@@ -91,7 +96,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'voltage')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_VOLTAGE)[0], expected_values)
 
     def test_getpdu_xcvr_rx_power_sensor_minus_infinity(self):
         """
@@ -107,7 +112,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'rx1power')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 1 + SENSOR_TYPE_PORT_RX_POWER)[0], expected_values)
 
     def test_getpdu_xcvr_rx_power_sensor(self):
         """
@@ -124,8 +129,7 @@ class TestSonicMIB(TestCase):
 
         # test for each channel except first, we already test above
         for channel in (2, 3, 4):
-            sensor = 'rx{}power'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_RX_POWER + channel)[0], expected_values)
 
     def test_getpdu_xcvr_tx_power_sensor(self):
         """
@@ -142,8 +146,7 @@ class TestSonicMIB(TestCase):
 
         # test for each channel except first, we already test above
         for channel in (1, 2, 3, 4):
-            sensor = 'tx{}power'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_POWER + channel)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor_unknown(self):
         """
@@ -159,7 +162,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.UNAVAILABLE
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'tx1bias')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 1 + SENSOR_TYPE_PORT_TX_BIAS)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor_overflow(self):
         """
@@ -175,7 +178,7 @@ class TestSonicMIB(TestCase):
             rfc3433.EntitySensorStatus.OK
         ]
 
-        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 'tx3bias')[0], expected_values)
+        self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, 3 + SENSOR_TYPE_PORT_TX_BIAS)[0], expected_values)
 
     def test_getpdu_xcvr_tx_bias_sensor(self):
         """
@@ -192,6 +195,4 @@ class TestSonicMIB(TestCase):
 
         # test for each channel
         for channel in (2, 4):
-            sensor = 'tx{}bias'.format(channel)
-            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, sensor)[0], expected_values)
-
+            self._test_getpdu_xcvr_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_BIAS + channel)[0], expected_values)

--- a/tests/test_sn.py
+++ b/tests/test_sn.py
@@ -21,6 +21,11 @@ from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_psu_se
 from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_fan_sub_id, get_fan_tachometers_sub_id
 from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_chassis_thermal_sub_id, get_transceiver_sub_id
 from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import get_transceiver_sensor_sub_id
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_TEMP
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_VOLTAGE
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_RX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_POWER
+from sonic_ax_impl.mibs.ietf.physical_entity_sub_oid_generator import SENSOR_TYPE_PORT_TX_BIAS
 from sonic_ax_impl.main import SonicMIB
 
 class TestSonicMIB(TestCase):
@@ -201,20 +206,20 @@ class TestSonicMIB(TestCase):
 
     def test_getpdu_xcvr_dom(self):
         expected_mib = {
-            get_transceiver_sensor_sub_id(1, 'temperature')[0]: "DOM Temperature Sensor for etp1",
-            get_transceiver_sensor_sub_id(1, 'voltage')[0]: "DOM Voltage Sensor for etp1",
-            get_transceiver_sensor_sub_id(1, 'rx1power')[0]: "DOM RX Power Sensor for etp1/1",
-            get_transceiver_sensor_sub_id(1, 'rx2power')[0]: "DOM RX Power Sensor for etp1/2",
-            get_transceiver_sensor_sub_id(1, 'rx3power')[0]: "DOM RX Power Sensor for etp1/3",
-            get_transceiver_sensor_sub_id(1, 'rx4power')[0]: "DOM RX Power Sensor for etp1/4",
-            get_transceiver_sensor_sub_id(1, 'tx1bias')[0]: "DOM TX Bias Sensor for etp1/1",
-            get_transceiver_sensor_sub_id(1, 'tx2bias')[0]: "DOM TX Bias Sensor for etp1/2",
-            get_transceiver_sensor_sub_id(1, 'tx3bias')[0]: "DOM TX Bias Sensor for etp1/3",
-            get_transceiver_sensor_sub_id(1, 'tx4bias')[0]: "DOM TX Bias Sensor for etp1/4",
-            get_transceiver_sensor_sub_id(1, 'tx1power')[0]: "DOM TX Power Sensor for etp1/1",
-            get_transceiver_sensor_sub_id(1, 'tx2power')[0]: "DOM TX Power Sensor for etp1/2",
-            get_transceiver_sensor_sub_id(1, 'tx3power')[0]: "DOM TX Power Sensor for etp1/3",
-            get_transceiver_sensor_sub_id(1, 'tx4power')[0]: "DOM TX Power Sensor for etp1/4",
+            get_transceiver_sensor_sub_id(1, SENSOR_TYPE_TEMP)[0]: "DOM Temperature Sensor for etp1",
+            get_transceiver_sensor_sub_id(1, SENSOR_TYPE_VOLTAGE)[0]: "DOM Voltage Sensor for etp1",
+            get_transceiver_sensor_sub_id(1, 1 + SENSOR_TYPE_PORT_RX_POWER)[0]: "DOM RX Power Sensor for etp1/1",
+            get_transceiver_sensor_sub_id(1, 2 + SENSOR_TYPE_PORT_RX_POWER)[0]: "DOM RX Power Sensor for etp1/2",
+            get_transceiver_sensor_sub_id(1, 3 + SENSOR_TYPE_PORT_RX_POWER)[0]: "DOM RX Power Sensor for etp1/3",
+            get_transceiver_sensor_sub_id(1, 4 + SENSOR_TYPE_PORT_RX_POWER)[0]: "DOM RX Power Sensor for etp1/4",
+            get_transceiver_sensor_sub_id(1, 1 + SENSOR_TYPE_PORT_TX_BIAS)[0]: "DOM TX Bias Sensor for etp1/1",
+            get_transceiver_sensor_sub_id(1, 2 + SENSOR_TYPE_PORT_TX_BIAS)[0]: "DOM TX Bias Sensor for etp1/2",
+            get_transceiver_sensor_sub_id(1, 3 + SENSOR_TYPE_PORT_TX_BIAS)[0]: "DOM TX Bias Sensor for etp1/3",
+            get_transceiver_sensor_sub_id(1, 4 + SENSOR_TYPE_PORT_TX_BIAS)[0]: "DOM TX Bias Sensor for etp1/4",
+            get_transceiver_sensor_sub_id(1, 1 + SENSOR_TYPE_PORT_TX_POWER)[0]: "DOM TX Power Sensor for etp1/1",
+            get_transceiver_sensor_sub_id(1, 2 + SENSOR_TYPE_PORT_TX_POWER)[0]: "DOM TX Power Sensor for etp1/2",
+            get_transceiver_sensor_sub_id(1, 3 + SENSOR_TYPE_PORT_TX_POWER)[0]: "DOM TX Power Sensor for etp1/3",
+            get_transceiver_sensor_sub_id(1, 4 + SENSOR_TYPE_PORT_TX_POWER)[0]: "DOM TX Power Sensor for etp1/4",
         }
 
         phyDescr, phyClass = 2, 5


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The current snmpagent implementation hardcoded qsfp lanes to 4, but qsfp-dd has 8 lanes. In that case snmp query only display the sensors of first 4 lanes. This PR is to fix it. 

**- How I did it**

1. read actual sensor status from redis db, now we only care temperature, voltage, txpower, rxpower, txbias.
2. sort sensor data to make sure it has a solid order
3. store the data to snmpagent data structure

**- How to verify it**

Manual test on master and run existing regression

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

