### PR TITLE
[sysName]: Implement sysName OID

### DIFF
--- a/src/sonic_ax_impl/main.py
+++ b/src/sonic_ax_impl/main.py
@@ -24,6 +24,7 @@ shutdown_task = None
 class SonicMIB(
     rfc1213.InterfacesMIB,
     rfc1213.IpMib,
+    rfc1213.SysNameMIB,
     rfc2737.PhysicalTableMIB,
     rfc3433.PhysicalSensorTableMIB,
     rfc2863.InterfaceMIBObjects,

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -693,9 +693,6 @@ class sysNameUpdater(MIBUpdater):
 
 
 class SysNameMIB(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.1.5'):
-    """
-
-    """
     updater = sysNameUpdater()
 
     sysName = MIBEntry('0', ValueType.OCTET_STRING, updater.get_sys_name)

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -679,8 +679,8 @@ class sysNameUpdater(MIBUpdater):
         self.db_conn.connect(self.db_conn.CONFIG_DB)
         device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
 
-        if device_metadata is not None and 'hostname' in device_metadata:
-             self.hostname = device_metadata['hostname']
+        if device_metadata and device_metadata.get('hostname'):
+            self.hostname = device_metadata['hostname']
 
     def update_data(self):
         return

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -1,5 +1,6 @@
 import ipaddress
 import python_arptable
+import socket
 from enum import unique, Enum
 from bisect import bisect_right
 
@@ -672,15 +673,14 @@ class sysNameUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
-        self.hostname = None
+        self.hostname = socket.gethostname()
 
     def reinit_data(self):
-        self.hostname = None
         self.db_conn.connect(self.db_conn.CONFIG_DB)
         device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
 
         if device_metadata is not None and 'hostname' in device_metadata:
-             self.hostname = str(device_metadata['hostname'])
+             self.hostname = device_metadata['hostname']
 
     def update_data(self):
         return

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -672,6 +672,15 @@ class sysNameUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
         self.db_conn = mibs.init_db()
+        self.hostname = None
+
+    def reinit_data(self):
+        self.hostname = None
+        self.db_conn.connect(self.db_conn.CONFIG_DB)
+        device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
+
+        if device_metadata is not None and 'hostname' in device_metadata:
+             self.hostname = str(device_metadata['hostname'])
 
     def update_data(self):
         return
@@ -680,14 +689,7 @@ class sysNameUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        self.db_conn.connect(mibs.CONFIG_DB)
-
-        device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
-
-        if device_metadata is not None and 'hostname' in device_metadata:
-             return str(device_metadata['hostname'])
-        else:
-             return None
+        return self.hostname
 
 
 class SysNameMIB(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.1.5'):

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -667,3 +667,33 @@ class InterfacesMIB(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.2'):
     # FIXME Placeholder
     ifSpecific = \
         SubtreeMIBEntry('2.1.22', if_updater, ValueType.OBJECT_IDENTIFIER, lambda sub_id: ObjectIdentifier.null_oid())
+
+class sysNameUpdater(MIBUpdater):
+    def __init__(self):
+        super().__init__()
+        self.db_conn = mibs.init_db()
+
+    def update_data(self):
+        return
+
+    def get_sys_name(self):
+        """
+        Subclass update interface information
+        """
+        self.db_conn.connect(mibs.CONFIG_DB)
+
+        device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
+
+        if device_metadata is not None and 'hostname' in device_metadata:
+             return str(device_metadata['hostname'])
+        else:
+             return None
+
+
+class SysNameMIB(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.1.5'):
+    """
+
+    """
+    updater = sysNameUpdater()
+
+    sysName = MIBEntry('0', ValueType.OCTET_STRING, updater.get_sys_name)

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -14,5 +14,9 @@
     "admin_status": "up",
     "alias": "mgmt2",
     "speed": 1000
+  },
+  "DEVICE_METADATA|localhost": {
+    "chassis_serial_number": "SAMPLETESTSN",
+    "hostname" : "test_hostname"
   }
 }

--- a/tests/mock_tables/global_db/config_db.json
+++ b/tests/mock_tables/global_db/config_db.json
@@ -14,5 +14,9 @@
     "admin_status": "up",
     "alias": "mgmt2",
     "speed": 1000
+  },
+ "DEVICE_METADATA|localhost": {
+   "chassis_serial_number": "SAMPLETESTSN",
+   "hostname" : "namespace_hostname"
   }
 }

--- a/tests/mock_tables/global_db/config_db.json
+++ b/tests/mock_tables/global_db/config_db.json
@@ -15,8 +15,8 @@
     "alias": "mgmt2",
     "speed": 1000
   },
- "DEVICE_METADATA|localhost": {
-   "chassis_serial_number": "SAMPLETESTSN",
-   "hostname" : "namespace_hostname"
+  "DEVICE_METADATA|localhost": {
+    "chassis_serial_number": "SAMPLETESTSN",
+    "hostname" : "namespace_hostname"
   }
 }

--- a/tests/namespace/test_sysname.py
+++ b/tests/namespace/test_sysname.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import importlib
+from unittest import TestCase
+
+from ax_interface import ValueType
+from ax_interface.pdu_implementations import GetPDU, GetNextPDU
+from ax_interface.encodings import ObjectIdentifier
+from ax_interface.constants import PduTypes
+from ax_interface.pdu import PDU, PDUHeader
+from ax_interface.mib import MIBTable
+from sonic_ax_impl.mibs.ietf import rfc1213
+import tests.mock_tables.dbconnector
+
+class TestGetNextPDU(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        tests.mock_tables.dbconnector.load_namespace_config()
+        importlib.reload(rfc1213)
+        cls.lut = MIBTable(rfc1213.SysNameMIB)
+
+    def test_getpdu_sysname(self):
+        oid = ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        n = len(response.values)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))))
+        self.assertEqual(str(value0.data), 'namespace_hostname')
+
+    @classmethod
+    def tearDownClass(cls):
+        tests.mock_tables.dbconnector.clean_up_config()

--- a/tests/namespace/test_sysname.py
+++ b/tests/namespace/test_sysname.py
@@ -18,6 +18,9 @@ class TestGetNextPDU(TestCase):
         tests.mock_tables.dbconnector.load_namespace_config()
         importlib.reload(rfc1213)
         cls.lut = MIBTable(rfc1213.SysNameMIB)
+        for updater in cls.lut.updater_instances:
+            updater.reinit_data()
+            updater.update_data()
 
     def test_getpdu_sysname(self):
         oid = ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))

--- a/tests/test_sysname.py
+++ b/tests/test_sysname.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from unittest import TestCase
+
+from unittest import TestCase
+
+from ax_interface import ValueType
+from ax_interface.pdu_implementations import GetPDU, GetNextPDU
+from ax_interface.encodings import ObjectIdentifier
+from ax_interface.constants import PduTypes
+from ax_interface.pdu import PDU, PDUHeader
+from ax_interface.mib import MIBTable
+from sonic_ax_impl.mibs.ietf import rfc1213
+
+class TestGetNextPDU(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lut = MIBTable(rfc1213.SysNameMIB)
+
+    def test_getpdu_sysname(self):
+        oid = ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        n = len(response.values)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))))
+        self.assertEqual(str(value0.data), 'test_hostname')

--- a/tests/test_sysname.py
+++ b/tests/test_sysname.py
@@ -16,6 +16,9 @@ class TestGetNextPDU(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.lut = MIBTable(rfc1213.SysNameMIB)
+        for updater in cls.lut.updater_instances:
+            updater.reinit_data()
+            updater.update_data()
 
     def test_getpdu_sysname(self):
         oid = ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))


### PR DESCRIPTION
[sysName]: Add sysName OID implementation in snmpagent.
sysName OID is currently supported by snmpd. Override this
implementation to make sure the latest hostname is taken
 from config db.
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add sysName OID implementation in snmpagent as mentioned in https://github.com/Azure/sonic-snmpagent/issues/170

**- How I did it**
- Add a new MIB class to support retrieving sysName from config_db
- Add unit-test to test sysName OID.

**- How to verify it**
Bring up snmp docker with the changes.
Configure  a new hostname using "config hostname <>" command.
Execute SNMP query to get 1.3.6.1.2.1.1.5.0, ensure new configured hostname is retrieved.
```
Testing result on sonic-vs platform:

admin@vlab-01:~$ sudo config hostname test
Running command: service hostname-config restart
Reloading Monit configuration ...
Reinitializing monit daemon
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
admin@vlab-01:~$ date
Thu 24 Dec 2020 02:30:04 AM UTC

admin@vlab-01:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 1.3.6.1.2.1.1.5.0
iso.3.6.1.2.1.1.5.0 = STRING: "vlab-01"
admin@vlab-01:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 1.3.6.1.2.1.1.5.0
iso.3.6.1.2.1.1.5.0 = STRING: "test"
admin@vlab-01:~$ date
Thu 24 Dec 2020 02:30:48 AM UTC
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

