### PR TITLE
[RouteUpdater]: Fix multi_asic mock function implementation and multi_asic variable name

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -63,7 +63,7 @@ class RouteUpdater(MIBUpdater):
             # For single-asic platform, front_ns will be empty list.
             if front_ns and db_conn.namespace not in front_ns:
                 continue
-            port_table = multi_asic.get_port_table(db_conn.namespace)
+            port_table = multi_asic.get_port_table_for_asic(db_conn.namespace)
             ent = db_conn.get_all(mibs.APPL_DB, route_str, blocking=False)
             if ent is None:
                 continue
@@ -79,8 +79,8 @@ class RouteUpdater(MIBUpdater):
                 if multi_asic.is_port_channel_internal(ifn, db_conn.namespace):
                     continue
                 if (ifn in port_table and
-                   multi_asic.ROLE in port_table[ifn] and
-                   port_table[ifn][multi_asic.ROLE] == multi_asic.INTERNAL_PORT): 
+                   multi_asic.PORT_ROLE in port_table[ifn] and
+                   port_table[ifn][multi_asic.PORT_ROLE] == multi_asic.INTERNAL_PORT): 
                     continue
                 sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
                 self.route_dest_list.append(sub_id)

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -75,13 +75,15 @@ class RouteUpdater(MIBUpdater):
                 ## This is to workaround the bug in current sonic-swss implementation
                 if ifn == "eth0" or ifn == "lo" or ifn == "docker0":
                     continue
+
                 # Ignore internal asic routes
                 if multi_asic.is_port_channel_internal(ifn, db_conn.namespace):
                     continue
                 if (ifn in port_table and
-                   multi_asic.PORT_ROLE in port_table[ifn] and
-                   port_table[ifn][multi_asic.PORT_ROLE] == multi_asic.INTERNAL_PORT): 
+                    multi_asic.PORT_ROLE in port_table[ifn] and
+                    port_table[ifn][multi_asic.PORT_ROLE] == multi_asic.INTERNAL_PORT):
                     continue
+
                 sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
                 self.route_dest_list.append(sub_id)
                 self.route_dest_map[sub_id] = ipn.network_address.packed

--- a/tests/mock_tables/multi_asic.py
+++ b/tests/mock_tables/multi_asic.py
@@ -34,7 +34,7 @@ def mock_is_port_channel_internal(port_channel, namespace=None):
     else:
         return True if port_channel in int_port_channel else False
 
-def mock_get_port_table(namespace=None):
+def mock_get_port_table_for_asic(namespace=None):
     if namespace is not None:
         fname = os.path.join(INPUT_DIR, namespace, 'config_db.json')
     else:
@@ -44,7 +44,7 @@ def mock_get_port_table(namespace=None):
     with open(fname) as f:
         db = json.load(f)
     for k in db:
-        if 'PORT_TABLE' in db:
+        if 'PORT_TABLE' in k:
             new_key = k[len('PORT_TABLE:'):]
             port_table[new_key] = db[k]
     return port_table
@@ -53,4 +53,4 @@ multi_asic.get_num_asics = mock_get_num_asics
 multi_asic.is_multi_asic = mock_is_multi_asic
 multi_asic.get_all_namespaces = mock_get_all_namespaces
 multi_asic.is_port_channel_internal = mock_is_port_channel_internal
-multi_asic.get_port_table = mock_get_port_table
+multi_asic.get_port_table_for_asic = mock_get_port_table_for_asic


### PR DESCRIPTION
[RouteUpdater]: Fix multi_asic mock function implementation.
Update multi_asic mock function to return port_table from config_db
was returning empty dictionary due to which RouteUpdater class
was not completely unit-tested as one of the condition check was
never set to true.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Fix multi_asic mock function implementation to get port_table information.  There was a mistake in mock_get_port_table function due to which port_table was always empty dictionary.
2. Use multi_asic.get_port_table_for_asic() function as we require port_table only of a specific namespace and do not require the entire port_table.
3. Fix the incorrect multi_asic variable name used in RouteUdpater.
Provides fix for https://github.com/Azure/sonic-snmpagent/issues/188

**- How I did it**
1. Update multi_asic mock_get_port_table_for_asic implementation.
3. Fix the incorrect multi_asic variable name used in RouteUdpater.

**- How to verify it**
Load updated docker and query 1.3.6.1.2.1.4.24 MIB. Verify the result.
"AttributeError: module 'sonic_py_common.multi_asic' has no attribute 'ROLE'" error message should not be seen in syslog .

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

