### PR TITLE
Fix 'key not found' exception in bgp4.py

### DIFF
--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -36,7 +36,7 @@ class BgpSessionUpdater(MIBUpdater):
             neigh_str = neigh_key
             neigh_str = neigh_str.split('|')[1]
             neigh_info = self.db_conn[db_index].get_all(mibs.STATE_DB, neigh_key, blocking=False)
-            if neigh_info is not None and 'state' in neigh_info:
+            if neigh_info:
                 state = neigh_info['state']
                 ip = ipaddress.ip_address(neigh_str)
                 if type(ip) is ipaddress.IPv4Address:

--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -1,8 +1,6 @@
-import socket
 from bisect import bisect_right
 from sonic_ax_impl import mibs
 from ax_interface import MIBMeta, ValueType, MIBUpdater, SubtreeMIBEntry
-from ax_interface.mib import MIBEntry
 from sonic_ax_impl.mibs import Namespace
 import ipaddress
 
@@ -22,7 +20,7 @@ class BgpSessionUpdater(MIBUpdater):
         super().__init__()
         self.db_conn = Namespace.init_namespace_dbs()
 
-        self.neigh_state_map = {} 
+        self.neigh_state_map = {}
         self.session_status_map = {}
         self.session_status_list = []
 
@@ -38,7 +36,7 @@ class BgpSessionUpdater(MIBUpdater):
             neigh_str = neigh_key
             neigh_str = neigh_str.split('|')[1]
             neigh_info = self.db_conn[db_index].get_all(mibs.STATE_DB, neigh_key, blocking=False)
-            if neigh_info is not None:
+            if neigh_info is not None and 'state' in neigh_info:
                 state = neigh_info['state']
                 ip = ipaddress.ip_address(neigh_str)
                 if type(ip) is ipaddress.IPv4Address:


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
A 'key not found' exception will be raised in bgp4.py if the state for a given neighbor is not found in STATE_DB. 
```
ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()
#012Traceback (most recent call last):
#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 43, in start
#012    self.update_data()#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/vendor/cisco/bgp4.py", line 42, in update_data
#012    state = neigh_info['state']
#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 345, in __getitem__
#012    return _swsscommon.FieldValueMap___getitem__(self, key)
#012IndexError: key not found
```
It is becaues an empty ```dict``` is returned by ```get_all``` when nothing is found for the given key. So check for ```None``` can't detect the error.

**- How I did it**
This commit addressed the issue by checking the key ```state```.

**- How to verify it**
Verified on A7260. No exception is observed after the update.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR fix exception caused by non existing key.
