### PR TITLE
Updated lldpRemManAddrTable to use all the management ip address associated with interface.

### DIFF
--- a/src/ax_interface/util.py
+++ b/src/ax_interface/util.py
@@ -1,3 +1,4 @@
+import ipaddress
 import re
 
 from ax_interface import constants
@@ -98,10 +99,12 @@ def mac_decimals(mac):
     """
     return tuple(int(h, 16) for h in mac.split(":"))
 
-def ip2tuple_v4(ip):
+def ip2byte_tuple(ip):
     """
-    >>> ip2tuple_v4("192.168.1.253")
+    >>> ip2byte_tuple("192.168.1.253")
     (192, 168, 1, 253)
+    >>> ip2byte_tuple("2001:db8::3")
+    (32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3)
     """
-    return tuple(int(bs) for bs in str(ip).split('.'))
+    return tuple(i for i in ipaddress.ip_address(ip).packed)
 

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -614,13 +614,13 @@ class LLDPRemManAddrUpdater(MIBUpdater):
     def get_subtype_and_exploded_ip(self, ip_str):
         try:
             ipaddress.IPv4Address(ip_str)
-            return ManAddrConst.man_addr_subtype_ipv4, ipaddress.ip_address(ip_str).exploded
+            return ManAddrConst.man_addr_subtype_ipv4, ip_str
         except ipaddress.AddressValueError:
             # not a valid IPv4
             pass
         try:
             ipaddress.IPv6Address(ip_str)
-            return ManAddrConst.man_addr_subtype_ipv6, ipaddress.ip_address(ip_str).exploded
+            return ManAddrConst.man_addr_subtype_ipv6, ipaddress.IPv6Address(ip_str).exploded
         except ipaddress.AddressValueError:
             # not a valid IPv6
             logger.warning("Invalid mgmt IP {}".format(ip_str))

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -517,19 +517,19 @@ class LLDPRemManAddrUpdater(MIBUpdater):
                 remote_index = int(lldp_kvs['lldp_rem_index'])
                 subtype, exploded_mgmt_ip = self.get_subtype_and_exploded_ip(mgmt_ip)
 
-                # Invalid Managent IP
+                # Invalid management IP
                 if not subtype or not exploded_mgmt_ip:
                     logger.warning("Invalid management IP {}".format(mgmt_ip))
                     continue
-                # Non-Unique Managemnt IP
+                # Non-Unique management IP
                 elif exploded_mgmt_ip in mgmt_ip_set:
                     continue
-                # IPv4 Managemnt IP
+                # IPv4 management IP
                 elif subtype == ManAddrConst.man_addr_subtype_ipv4:
                     addr_subtype_sub_oid = 4
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in exploded_mgmt_ip.split('.')])
                     mgmt_ip_set.add(exploded_mgmt_ip)
-                # IPv6 Managemnt IP
+                # IPv6 management IP
                 elif subtype == ManAddrConst.man_addr_subtype_ipv6:
                     addr_subtype_sub_oid = 6
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i, 16) if i else 0 for i in exploded_mgmt_ip.split(':')])

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -516,7 +516,7 @@ class LLDPRemManAddrUpdater(MIBUpdater):
                 time_mark = int(lldp_kvs['lldp_rem_time_mark'])
                 remote_index = int(lldp_kvs['lldp_rem_index'])
                 subtype, exploded_mgmt_ip = self.get_subtype_and_exploded_ip(mgmt_ip)
-                if exploded_mgmt_ip in mgmt_ip_set:
+                if exploded_mgmt_ip and exploded_mgmt_ip in mgmt_ip_set:
                     continue
                 elif subtype == ManAddrConst.man_addr_subtype_ipv4:
                     addr_subtype_sub_oid = 4

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -516,19 +516,26 @@ class LLDPRemManAddrUpdater(MIBUpdater):
                 time_mark = int(lldp_kvs['lldp_rem_time_mark'])
                 remote_index = int(lldp_kvs['lldp_rem_index'])
                 subtype, exploded_mgmt_ip = self.get_subtype_and_exploded_ip(mgmt_ip)
-                if exploded_mgmt_ip and exploded_mgmt_ip in mgmt_ip_set:
+
+                # Invalid Managent IP
+                if not subtype or not exploded_mgmt_ip:
+                    logger.warning("Invalid management IP {}".format(mgmt_ip))
                     continue
+                # Non-Unique Managemnt IP
+                elif exploded_mgmt_ip in mgmt_ip_set:
+                    continue
+                # IPv4 Managemnt IP
                 elif subtype == ManAddrConst.man_addr_subtype_ipv4:
                     addr_subtype_sub_oid = 4
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in exploded_mgmt_ip.split('.')])
                     mgmt_ip_set.add(exploded_mgmt_ip)
+                # IPv6 Managemnt IP
                 elif subtype == ManAddrConst.man_addr_subtype_ipv6:
                     addr_subtype_sub_oid = 6
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i, 16) if i else 0 for i in exploded_mgmt_ip.split(':')])
                     mgmt_ip_set.add(exploded_mgmt_ip)
                 else:
-                    logger.warning("Invalid management IP {}".format(exploded_mgmt_ip))
-                    continue
+                    pass
                 self.if_range.append((time_mark,
                                       if_oid,
                                       remote_index,

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -514,7 +514,6 @@ class LLDPRemManAddrUpdater(MIBUpdater):
                 time_mark = int(lldp_kvs['lldp_rem_time_mark'])
                 remote_index = int(lldp_kvs['lldp_rem_index'])
                 subtype = self.get_subtype(mgmt_ip)
-                ip_hex = self.get_ip_hex(mgmt_ip, subtype)
                 if subtype == ManAddrConst.man_addr_subtype_ipv4:
                     addr_subtype_sub_oid = 4
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i) for i in mgmt_ip.split('.')])

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -521,7 +521,7 @@ class LLDPRemManAddrUpdater(MIBUpdater):
                     addr_subtype_sub_oid = 6
                     mgmt_ip_sub_oid = (addr_subtype_sub_oid, *[int(i, 16) if i else 0 for i in mgmt_ip.split(':')])
                 else:
-                    logger.warning("Invalid management IP {}".format(mgmt_ip_str))
+                    logger.warning("Invalid management IP {}".format(mgmt_ip))
                     continue
                 self.if_range.append((time_mark,
                                       if_oid,

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -8,7 +8,7 @@ from sonic_ax_impl import mibs
 from sonic_ax_impl.mibs import Namespace
 from ax_interface.mib import MIBMeta, ValueType, MIBUpdater, MIBEntry, SubtreeMIBEntry, OverlayAdpaterMIBEntry, OidMIBEntry
 from ax_interface.encodings import ObjectIdentifier
-from ax_interface.util import mac_decimals, ip2tuple_v4
+from ax_interface.util import mac_decimals, ip2byte_tuple
 
 @unique
 class DbTables(int, Enum):
@@ -99,7 +99,7 @@ class ArpUpdater(MIBUpdater):
         # if MAC is all zero
         #if not any(mac): continue
 
-        iptuple = ip2tuple_v4(ip)
+        iptuple = ip2byte_tuple(ip)
 
         subid = (if_index,) + iptuple
         self.arp_dest_map[subid] = machex
@@ -154,7 +154,7 @@ class NextHopUpdater(MIBUpdater):
                 nexthops = ent["nexthop"]
                 for nh in nexthops.split(','):
                     # TODO: if ipn contains IP range, create more sub_id here
-                    sub_id = ip2tuple_v4(ipn.network_address)
+                    sub_id = ip2byte_tuple(ipn.network_address)
                     self.route_list.append(sub_id)
                     self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
                     break # Just need the first nexthop

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -3,7 +3,7 @@ import ipaddress
 from sonic_ax_impl import mibs
 from sonic_ax_impl.mibs import Namespace
 from ax_interface import MIBMeta, ValueType, MIBUpdater, SubtreeMIBEntry
-from ax_interface.util import ip2tuple_v4
+from ax_interface.util import ip2byte_tuple
 from bisect import bisect_right
 from sonic_py_common import multi_asic
 
@@ -46,7 +46,7 @@ class RouteUpdater(MIBUpdater):
 
         ## The nexthop for loopbacks should be all zero
         for loip in self.loips:
-            sub_id = ip2tuple_v4(loip) + (255, 255, 255, 255) + (self.tos,) + (0, 0, 0, 0)
+            sub_id = ip2byte_tuple(loip) + (255, 255, 255, 255) + (self.tos,) + (0, 0, 0, 0)
             self.route_dest_list.append(sub_id)
             self.route_dest_map[sub_id] = self.loips[loip].packed
 
@@ -84,7 +84,7 @@ class RouteUpdater(MIBUpdater):
                     port_table[ifn][multi_asic.PORT_ROLE] == multi_asic.INTERNAL_PORT):
                     continue
 
-                sub_id = ip2tuple_v4(ipn.network_address) + ip2tuple_v4(ipn.netmask) + (self.tos,) + ip2tuple_v4(nh)
+                sub_id = ip2byte_tuple(ipn.network_address) + ip2byte_tuple(ipn.netmask) + (self.tos,) + ip2byte_tuple(nh)
                 self.route_dest_list.append(sub_id)
                 self.route_dest_map[sub_id] = ipn.network_address.packed
 

--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -1,6 +1,7 @@
 from bisect import bisect_right
 from sonic_ax_impl import mibs
 from ax_interface import MIBMeta, ValueType, MIBUpdater, SubtreeMIBEntry
+from ax_interface.util import ip2byte_tuple
 from sonic_ax_impl.mibs import Namespace
 import ipaddress
 
@@ -43,7 +44,7 @@ class BgpSessionUpdater(MIBUpdater):
                     oid_head = (1, 4)
                 else:
                     oid_head = (2, 16)
-                oid_ip = tuple(i for i in ip.packed)
+                oid_ip = ip2byte_tuple(neigh_str)
 
                 if state.isdigit():
                     status = 6

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -333,7 +333,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet24",
-    "lldp_rem_man_addr": "10.224.25.123"
+    "lldp_rem_man_addr": "10.224.25.123,2603:10e2:290:5016::"
   },
   "LLDP_ENTRY_TABLE:Ethernet96": {
     "lldp_rem_port_id_subtype": "5",

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -11,7 +11,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet1",
-    "lldp_rem_man_addr": "10.224.25.100"
+    "lldp_rem_man_addr": "10.224.25.100,2603:10e2:290:5016::"
   },
   "LLDP_ENTRY_TABLE:Ethernet4": {
     "lldp_rem_port_id_subtype": "5",
@@ -25,7 +25,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet2",
-    "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
+    "lldp_rem_man_addr": "fe80::268a::7ff:fe3f:834c,10.224.25.101"
   },
   "LLDP_ENTRY_TABLE:Ethernet8": {
     "lldp_rem_port_id_subtype": "5",
@@ -53,7 +53,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4",
-    "lldp_rem_man_addr": "10.224.25.103"
+    "lldp_rem_man_addr": "fe80:268a::7ff:fe3f:834c"
   },
   "LLDP_ENTRY_TABLE:Ethernet16": {
     "lldp_rem_port_id_subtype": "5",
@@ -67,7 +67,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet5",
-    "lldp_rem_man_addr": "10.224.25.104"
+    "lldp_rem_man_addr": ""
   },
   "LLDP_ENTRY_TABLE:Ethernet20": {
     "lldp_rem_port_id_subtype": "5",

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -5,13 +5,13 @@
     "lldp_rem_index": "1",
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
-    "lldp_rem_time_mark": "18545",
+    "lldp_rem_time_mark": "0",
     "lldp_rem_sys_cap_enabled": "28 00",
     "lldp_rem_port_desc": " ",
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet1",
-    "lldp_rem_man_addr": "10.224.25.101,fe80:268a::7ff:fe3f:834c"
+    "lldp_rem_man_addr": "10.224.25.123,2603:10e2:290:5016::"
   },
   "LLDP_ENTRY_TABLE:Ethernet4": {
     "lldp_rem_port_id_subtype": "5",

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -11,7 +11,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet1",
-    "lldp_rem_man_addr": "10.224.25.100"
+    "lldp_rem_man_addr": "10.224.25.101,fe80:268a::7ff:fe3f:834c"
   },
   "LLDP_ENTRY_TABLE:Ethernet4": {
     "lldp_rem_port_id_subtype": "5",
@@ -25,7 +25,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet2",
-    "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
+    "lldp_rem_man_addr": "fe80::268a::7ff:fe3f:834c,10.224.25.102"
   },
   "LLDP_LOC_CHASSIS": {
     "lldp_loc_chassis_id_subtype": "5",

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -11,7 +11,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet3",
-    "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
+    "lldp_rem_man_addr": "10.224.25.102"
   },
   "LLDP_ENTRY_TABLE:Ethernet12": {
     "lldp_rem_port_id_subtype": "5",
@@ -25,7 +25,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4",
-    "lldp_rem_man_addr": "10.224.25.102"
+    "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
   },
   "LLDP_LOC_CHASSIS": {
     "lldp_loc_chassis_id_subtype": "5",

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -25,7 +25,7 @@
     "lldp_rem_chassis_id_subtype": "4",
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4",
-    "lldp_rem_man_addr": "fe80::268a:7ff:fe3f:834c"
+    "lldp_rem_man_addr": "fe80:268a::7ff:fe3f:834c"
   },
   "LLDP_LOC_CHASSIS": {
     "lldp_loc_chassis_id_subtype": "5",

--- a/tests/mock_tables/asic2/appl_db.json
+++ b/tests/mock_tables/asic2/appl_db.json
@@ -1,4 +1,18 @@
 {
+  "LLDP_ENTRY_TABLE:Ethernet16": {
+    "lldp_rem_port_id_subtype": "5",
+    "lldp_rem_sys_cap_supported": "28 00",
+    "lldp_rem_index": "1",
+    "lldp_rem_chassis_id": "00:11:22:33:44:55",
+    "lldp_rem_sys_desc": "I'm a little teapot.",
+    "lldp_rem_time_mark": "18543",
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_port_desc": " ",
+    "lldp_rem_chassis_id_subtype": "4",
+    "lldp_rem_sys_name": "switch13",
+    "lldp_rem_port_id": "Ethernet5",
+    "lldp_rem_man_addr": ""
+  },
   "LLDP_LOC_CHASSIS": {
     "lldp_loc_chassis_id_subtype": "5",
     "lldp_loc_chassis_id": "00:11:22:AB:CD:EF",
@@ -7,6 +21,11 @@
     "lldp_loc_sys_cap_enabled": "28 00",
     "lldp_loc_sys_cap_supported": "28 00",
     "lldp_loc_man_addr": "fe80::ce37:abff:feec:de9c"
+  },
+  "PORT_TABLE:Ethernet16": {
+    "description": "snowflake",
+    "alias": "etp5",
+    "speed": 100000
   },
   "PORT_TABLE:Ethernet-BP16": {
     "description": "backplane",

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -168,35 +168,39 @@ class TestLLDPMIB(TestCase):
 
 
         # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 102))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 102))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
         # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
         # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 13))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543,  
+                                               13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -124,36 +124,92 @@ class TestLLDPMIB(TestCase):
 
 
     def test_subtype_lldp_rem_man_addr_table(self):
+
+        # Get the first entry of walk. We will get IPv4 Address associated with Ethernet0 Port
         # Verfiy both valid ipv4 and ipv6 address exit
         for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 1))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy both valid ipv4 and invalid ipv6 address exit
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 5))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy only valid ipv4 address exit
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 9))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy only valid ipv6 address exit
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 13))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy no mgmt address exit
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 17))
-            self.assertIsNone(ret)
-            print(ret)
+            oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry))
+            get_pdu = GetNextPDU(
+                header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+                oids=[oid]
+            )
+            response = get_pdu.make_response(self.lut)
+            value0 = response.values[0]
+            self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 0, 1, 1, 1, 4, 10, 224, 25, 123))))
+            if entry == 3:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 2)
+            elif entry == 4:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 0)
+            else:
+                self.assertEqual(value0.type_, ValueType.OBJECT_IDENTIFIER)
+                self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
+
+            # Get next on above to get IPv6 Entry. We will get IPv6 Address associated with Ethernet0 Port
+            oid = ObjectIdentifier(16, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 0, 1, 1, 1, 16))
+            get_pdu = GetNextPDU(
+                header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+                oids=[oid]
+            )
+            response = get_pdu.make_response(self.lut)
+            value0 = response.values[0]
+            self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 1, 0, 
+                                                   (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 0, 1, 1, 2, 16, 38, 3, 16, 226, 2, 144, 80, 22, 0, 0, 0, 0, 0, 0, 0, 0))))
+            if entry == 3:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 2)
+            elif entry == 4:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 0)
+            else:
+                self.assertEqual(value0.type_, ValueType.OBJECT_IDENTIFIER)
+                self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
+
+
+        # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 13))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy no mgmt address exit. Ethernet16 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 17))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        # Should result End of Mib View
+        self.assertEqual(value0.type_, ValueType.END_OF_MIB_VIEW)
 
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -124,10 +124,35 @@ class TestLLDPMIB(TestCase):
 
 
     def test_subtype_lldp_rem_man_addr_table(self):
+        # Verfiy both valid ipv4 and ipv6 address exit
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy both valid ipv4 and invalid ipv6 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 5))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy only valid ipv4 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 9))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy only valid ipv6 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 13))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy no mgmt address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 17))
+            self.assertIsNone(ret)
             print(ret)
 
     def test_local_port_identification(self):

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -126,7 +126,7 @@ class TestLLDPMIB(TestCase):
     def test_subtype_lldp_rem_man_addr_table(self):
 
         # Get the first entry of walk. We will get IPv4 Address associated with Ethernet0 Port
-        # Verfiy both valid ipv4 and ipv6 address exit
+        # Verfiy both valid ipv4 and ipv6 address exist
         for entry in range(3, 6):
             oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry))
             get_pdu = GetNextPDU(
@@ -167,7 +167,7 @@ class TestLLDPMIB(TestCase):
                 self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
 
 
-        # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
+        # Verfiy both valid ipv4 and invalid ipv6 address exist. Ethernet5 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 102))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
@@ -179,7 +179,7 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
-        # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
+        # Verfiy only valid ipv4 address exist. Ethernet8 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
@@ -191,7 +191,7 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
-        # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
+        # Verfiy only valid ipv6 address exist. Ethernet12 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -106,36 +106,92 @@ class TestLLDPMIB(TestCase):
 
 
     def test_subtype_lldp_rem_man_addr_table(self):
-        # Verfiy both valid ipv4 and ipv6 address exist
+        # Get the first entry of walk. We will get IPv4 Address associated with Ethernet92 Port
+        # Verfiy both valid ipv4 and ipv6 address exit
         for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 1))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy valid ipv4 and invalid ipv6 address exist
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 5))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy only valid ipv4 address exist
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 9))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy only valid ipv6 address exist
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 13))
-            self.assertIsNotNone(ret)
-            print(ret)
-        # Verfiy no mgmt address exist
-        for entry in range(3, 6):
-            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
-            ret = mib_entry(sub_id=(1, 17))
-            self.assertIsNone(ret)
-            print(ret)
+            oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry))
+            get_pdu = GetNextPDU(
+                header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+                oids=[oid]
+            )
+            response = get_pdu.make_response(self.lut)
+            value0 = response.values[0]
+            self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 32, 93, 1, 1, 4, 10, 224, 25, 123))))
+            if entry == 3:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 2)
+            elif entry == 4:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 0)
+            else:
+                self.assertEqual(value0.type_, ValueType.OBJECT_IDENTIFIER)
+                self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
+
+            # Get next on above to get IPv6 Entry. We will get IPv6 Address associated with Ethernet92 Port
+            oid = ObjectIdentifier(16, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 32, 93, 1, 1, 16))
+            get_pdu = GetNextPDU(
+                header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+                oids=[oid]
+            )
+            response = get_pdu.make_response(self.lut)
+            value0 = response.values[0]
+            self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 1, 0, 
+                                                   (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry, 32, 93, 1, 2, 16, 38, 3, 16, 226, 2, 144, 80, 22, 0, 0, 0, 0, 0, 0, 0, 0))))
+            if entry == 3:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 2)
+            elif entry == 4:
+                self.assertEqual(value0.type_, ValueType.INTEGER)
+                self.assertEqual(value0.data, 0)
+            else:
+                self.assertEqual(value0.type_, ValueType.OBJECT_IDENTIFIER)
+                self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
+
+        # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 13))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
+
+        # Verfiy no mgmt address exit. Ethernet16 has this config.
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 17))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+        response = get_pdu.make_response(self.lut)
+        value0 = response.values[0]
+        # Should move to other interface. Ethernet22
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 21, 1, 1, 4, 10, 224, 25, 105))))
+        self.assertEqual(value0.type_, ValueType.INTEGER)
+        self.assertEqual(value0.data, 2)
 
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -107,7 +107,7 @@ class TestLLDPMIB(TestCase):
 
     def test_subtype_lldp_rem_man_addr_table(self):
         # Get the first entry of walk. We will get IPv4 Address associated with Ethernet92 Port
-        # Verfiy both valid ipv4 and ipv6 address exit
+        # Verfiy both valid ipv4 and ipv6 address exist
         for entry in range(3, 6):
             oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry))
             get_pdu = GetNextPDU(
@@ -147,7 +147,7 @@ class TestLLDPMIB(TestCase):
                 self.assertEqual(value0.type_, ValueType.OBJECT_IDENTIFIER)
                 self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
 
-        # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
+        # Verfiy both valid ipv4 and invalid ipv6 address exist. Ethernet5 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 101))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
@@ -159,7 +159,7 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
-        # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
+        # Verfiy only valid ipv4 address exist. Ethernet8 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
@@ -171,7 +171,7 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
-        # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
+        # Verfiy only valid ipv6 address exist. Ethernet12 has this config.
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))
         get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
@@ -184,7 +184,7 @@ class TestLLDPMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
-        # Verfiy no mgmt address exit. Ethernet16 has this config.
+        # Verfiy no mgmt address exist. Ethernet16 has this config.
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 17))
         get_pdu = GetNextPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -106,10 +106,35 @@ class TestLLDPMIB(TestCase):
 
 
     def test_subtype_lldp_rem_man_addr_table(self):
+        # Verfiy both valid ipv4 and ipv6 address exit
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy valid ipv4 and invalid ipv6 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 5))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy only valid ipv4 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 9))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy only valid ipv6 address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 13))
+            self.assertIsNotNone(ret)
+            print(ret)
+        # Verfiy no mgmt address exit
+        for entry in range(3, 6):
+            mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
+            ret = mib_entry(sub_id=(1, 17))
+            self.assertIsNone(ret)
             print(ret)
 
     def test_local_port_identification(self):

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -148,35 +148,39 @@ class TestLLDPMIB(TestCase):
                 self.assertEqual(str(value0.data), str(ObjectIdentifier(5, 2, 0, 0, (1, 2, 2, 1, 1))))
 
         # Verfiy both valid ipv4 and invalid ipv6 address exit. Ethernet5 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 101))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 5, 1, 1, 4, 10, 224, 25, 101))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
         # Verfiy only valid ipv4 address exit. Ethernet8 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18543, 9, 1, 1, 4, 10, 224, 25, 102))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 
         # Verfiy only valid ipv6 address exiit. Ethernet12 has this config.
-        oid = ObjectIdentifier(11, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 13))
-        get_pdu = GetNextPDU(
+        oid = ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545, 13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))
+        get_pdu = GetPDU(
             header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
             oids=[oid]
         )
         response = get_pdu.make_response(self.lut)
         value0 = response.values[0]
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(20, 0, 0, 0, (1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, 3, 18545,  
+                                               13, 1, 2, 16, 254, 128, 38, 138, 0, 0, 0, 0, 0, 0, 7, 255, 254, 63, 131, 76))))
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(value0.data, 2)
 

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -106,31 +106,31 @@ class TestLLDPMIB(TestCase):
 
 
     def test_subtype_lldp_rem_man_addr_table(self):
-        # Verfiy both valid ipv4 and ipv6 address exit
+        # Verfiy both valid ipv4 and ipv6 address exist
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 1))
             self.assertIsNotNone(ret)
             print(ret)
-        # Verfiy valid ipv4 and invalid ipv6 address exit
+        # Verfiy valid ipv4 and invalid ipv6 address exist
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 5))
             self.assertIsNotNone(ret)
             print(ret)
-        # Verfiy only valid ipv4 address exit
+        # Verfiy only valid ipv4 address exist
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 9))
             self.assertIsNotNone(ret)
             print(ret)
-        # Verfiy only valid ipv6 address exit
+        # Verfiy only valid ipv6 address exist
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 13))
             self.assertIsNotNone(ret)
             print(ret)
-        # Verfiy no mgmt address exit
+        # Verfiy no mgmt address exist
         for entry in range(3, 6):
             mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 4, 2, 1, entry)]
             ret = mib_entry(sub_id=(1, 17))


### PR DESCRIPTION
Why I did:

- Fixes:-
https://github.com/Azure/sonic-buildimage/issues/7036
https://github.com/Azure/sonic-buildimage/issues/6636

- Updated to use prefix of 16 byte instead of 6 byte for Ipv6 Management Address. Confirmed with other Vendor Nos

- Fixed `lookup()` so that get-next work correctly from test-cases.

- Updated all files to use new utility API  `ip2byte_tuple()`

How I did:

- Loop through all valid and unique management ip  address associated 
  with remote lldp interface and append to the the oid key list.

- Removed some of utility API as they were not being used.

How I verify:

- Extend Unit test case to cover all possible combination of management ip address
- Verify the snmpwalk when both v4 and v6 address are present

```
admin@str-sxxxx-on-2:~$ redis-cli -n 0
127.0.0.1:6379> hgetall "LLDP_ENTRY_TABLE:eth0"
 1) "lldp_rem_sys_name"
 2) "str-22ex-235ab08"
 3) "lldp_rem_index"
 4) "1"
 5) "lldp_rem_sys_desc"
 6) "Juniper Networks, Inc. ex2200-48t-4g , version 12.3R4.6 Build date: 2013-09-13 02:53:16 UTC "
 7) "lldp_rem_man_addr"
 8) "10.224.25.100,2603:10e2:290:5016::"
 9) "lldp_rem_time_mark"
10) "84379"
11) "lldp_rem_port_id"
12) "ge-0/0/12"
13) "lldp_rem_sys_cap_supported"
14) "28 00"
15) "lldp_rem_sys_cap_enabled"
16) "28 00"
17) "lldp_rem_chassis_id_subtype"
18) "4"
19) "lldp_rem_port_id_subtype"
20) "5"
21) "lldp_rem_port_desc"
22) "ge-0/0/12.0"
23) "lldp_rem_chassis_id"
24) "f4:b5:2f:56:2d:80"


root@str-sxxxx-on-2:/# snmpwalk -v2c -c msft 127.0.0.1 1.0.8802.1.1.2.1.4.2
iso.0.8802.1.1.2.1.4.2.1.5.84379.10000.1.1.4.10.224.25.100 = OID: iso.3.6.1.2.1.2.2.1.1
iso.0.8802.1.1.2.1.4.2.1.5.84379.10000.1.2.6.9731.4322.656.20502.0.0 = OID: iso.3.6.1.2.1.2.2.1.1
```