### PR TITLE
Temporarily lower the logging level for invalid FDB, which is a known issue on Mellanox

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -96,7 +96,7 @@ class FdbUpdater(MIBUpdater):
 
             vlanmac = self.fdb_vlanmac(fdb)
             if not vlanmac:
-                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed in fdb_vlanmac().".format(fdb_str))
+                mibs.logger.debug("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed in fdb_vlanmac().".format(fdb_str))
                 continue
             self.vlanmac_ifindex_map[vlanmac] = port_index
             self.vlanmac_ifindex_list.append(vlanmac)


### PR DESCRIPTION
**- What I did**
Mellanox has collected some FDBs on default VLAN, but the VLAN entry has no attributes, so it trigger this syslog message.

**- How I did it**

**- How to verify it**

**- Description for the changelog**


