### PR TITLE
[multi-asic]: Udpate to use SonicDBConfig from swsscommon

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -219,7 +219,12 @@ def init_db():
     Connects to DB
     :return: db_conn
     """
-    SonicDBConfig.load_sonic_global_db_config()
+    if not SonicDBConfig.isInit():
+        if multi_asic.is_multi_asic():
+            # Load the global config file database_global.json once.
+            SonicDBConfig.load_sonic_global_db_config()
+        else:
+            SonicDBConfig.initialize()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
     db_conn = SonicV2Connector(**redis_kwargs)
@@ -539,9 +544,11 @@ class Namespace:
     @staticmethod
     def init_namespace_dbs():
         db_conn = []
-        if multi_asic.is_multi_asic():
-            SonicDBConfig.load_sonic_global_db_config()
-
+        if not SonicDBConfig.isInit():
+            if multi_asic.is_multi_asic():
+                SonicDBConfig.load_sonic_global_db_config()
+            else:
+                SonicDBConfig.initialize()
         # Ensure that db connector of default namespace is the first element of
         # db_conn list.
         db_conn.append(SonicV2Connector(use_unix_socket_path=True, namespace=multi_asic.DEFAULT_NAMESPACE, decode_responses=True))

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -224,7 +224,7 @@ def init_db():
             # Load the global config file database_global.json once.
             SonicDBConfig.load_sonic_global_db_config()
         else:
-            SonicDBConfig.initialize()
+            SonicDBConfig.load_sonic_db_config()
     # SyncD database connector. THIS MUST BE INITIALIZED ON A PER-THREAD BASIS.
     # Redis PubSub objects (such as those within swsssdk) are NOT thread-safe.
     db_conn = SonicV2Connector(**redis_kwargs)
@@ -548,7 +548,7 @@ class Namespace:
             if multi_asic.is_multi_asic():
                 SonicDBConfig.load_sonic_global_db_config()
             else:
-                SonicDBConfig.initialize()
+                SonicDBConfig.load_sonic_db_config()
         # Ensure that db connector of default namespace is the first element of
         # db_conn list.
         db_conn.append(SonicV2Connector(use_unix_socket_path=True))

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -551,7 +551,7 @@ class Namespace:
                 SonicDBConfig.load_sonic_db_config()
         # Ensure that db connector of default namespace is the first element of
         # db_conn list.
-        db_conn.append(SonicV2Connector(use_unix_socket_path=True))
+        db_conn.append(SonicV2Connector(use_unix_socket_path=True, namespace=multi_asic.DEFAULT_NAMESPACE))
         ns_list = list(SonicDBConfig.get_ns_list())
         ns_list.remove(multi_asic.DEFAULT_NAMESPACE)
         for namespace in ns_list:

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -551,11 +551,11 @@ class Namespace:
                 SonicDBConfig.initialize()
         # Ensure that db connector of default namespace is the first element of
         # db_conn list.
-        db_conn.append(SonicV2Connector(use_unix_socket_path=True, namespace=multi_asic.DEFAULT_NAMESPACE, decode_responses=True))
+        db_conn.append(SonicV2Connector(use_unix_socket_path=True))
         ns_list = list(SonicDBConfig.get_ns_list())
         ns_list.remove(multi_asic.DEFAULT_NAMESPACE)
         for namespace in ns_list:
-            db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace, decode_responses=True)
+            db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
             db_conn.append(db)
 
         Namespace.connect_namespace_dbs(db_conn)

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -550,8 +550,7 @@ class Namespace:
             else:
                 SonicDBConfig.load_sonic_db_config()
         host_namespace_idx = 0
-        ns_list = list(SonicDBConfig.get_ns_list())
-        for idx, namespace in enumerate(ns_list): 
+        for idx, namespace in enumerate(SonicDBConfig.get_ns_list()): 
             if namespace == multi_asic.DEFAULT_NAMESPACE:
                 host_namespace_idx = idx
             db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -551,18 +551,15 @@ class Namespace:
                 SonicDBConfig.load_sonic_db_config()
         host_namespace_idx = 0
         ns_list = list(SonicDBConfig.get_ns_list())
-        for namespace in ns_list:
+        for idx, namespace in enumerate(ns_list): 
             if namespace == multi_asic.DEFAULT_NAMESPACE:
-                host_namespace_idx = ns_list.index(namespace)
+                host_namespace_idx = idx
             db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
             db_conn.append(db)
         # Ensure that db connector of default namespace is the first element of
         # db_conn list.
-        if host_namespace_idx != 0:
-            tmp_swap = db_conn[0]
-            db_conn[0] = db_conn[host_namespace_idx]
-            db_conn[host_namespace_idx] = tmp_swap
-        
+        db_conn[0], db_conn[host_namespace_idx] = db_conn[host_namespace_idx], db_conn[0]
+
         Namespace.connect_namespace_dbs(db_conn)
         return db_conn
 

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -549,15 +549,20 @@ class Namespace:
                 SonicDBConfig.load_sonic_global_db_config()
             else:
                 SonicDBConfig.load_sonic_db_config()
-        # Ensure that db connector of default namespace is the first element of
-        # db_conn list.
-        db_conn.append(SonicV2Connector(use_unix_socket_path=True, namespace=multi_asic.DEFAULT_NAMESPACE))
+        host_namespace_idx = 0
         ns_list = list(SonicDBConfig.get_ns_list())
-        ns_list.remove(multi_asic.DEFAULT_NAMESPACE)
         for namespace in ns_list:
+            if namespace == multi_asic.DEFAULT_NAMESPACE:
+                host_namespace_idx = ns_list.index(namespace)
             db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
             db_conn.append(db)
-
+        # Ensure that db connector of default namespace is the first element of
+        # db_conn list.
+        if host_namespace_idx != 0:
+            tmp_swap = db_conn[0]
+            db_conn[0] = db_conn[host_namespace_idx]
+            db_conn[host_namespace_idx] = tmp_swap
+        
         Namespace.connect_namespace_dbs(db_conn)
         return db_conn
 

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -134,6 +134,13 @@ class SwssSyncClient(mockredis.MockRedis):
         # Find every key that matches the pattern
         return [key for key in self.redis.keys() if regex.match(key)]
 
+def _isInit():
+    return   SonicDBConfig._sonic_db_config_init
+
+def  _initialize():
+    SonicDBConfig.load_sonic_db_config(
+        sonic_db_file_path=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'database_config.json'))
 
 DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification
 mockredis.MockRedis.config_set = config_set
@@ -141,6 +148,8 @@ redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector
 swsscommon.SonicDBConfig = SonicDBConfig
+SonicDBConfig.isInit = _isInit
+SonicDBConfig.initialize = _initialize
 
 # pytest case collecting will import some module before monkey patch, so reload
 from importlib import reload

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -9,6 +9,7 @@ from swsssdk import SonicV2Connector
 from swsssdk import SonicDBConfig
 from swsssdk.interface import DBInterface
 from swsscommon import swsscommon
+from sonic_py_common import multi_asic
 
 
 if sys.version_info >= (3, 0):
@@ -139,6 +140,7 @@ mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector
+swsscommon.SonicDBConfig = SonicDBConfig
 
 # pytest case collecting will import some module before monkey patch, so reload
 from importlib import reload

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -134,22 +134,12 @@ class SwssSyncClient(mockredis.MockRedis):
         # Find every key that matches the pattern
         return [key for key in self.redis.keys() if regex.match(key)]
 
-def _isInit():
-    return   SonicDBConfig._sonic_db_config_init
-
-def  _initialize():
-    SonicDBConfig.load_sonic_db_config(
-        sonic_db_file_path=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'database_config.json'))
-
 DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification
 mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector
 swsscommon.SonicDBConfig = SonicDBConfig
-SonicDBConfig.isInit = _isInit
-SonicDBConfig.initialize = _initialize
 
 # pytest case collecting will import some module before monkey patch, so reload
 from importlib import reload


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update snmpagent to use SonicDBConfig from swsscommon.

**- How I did it**
- Update import of SonicDBConfig 
- init_namespace_dbs should return list of all namespace connector classes. Ensure that the list ordering is maintained such that the first element of the list is of the default namespace.
 
**- How to verify it**
Tested on single asic VS; SNMP service starts without any error log.
Execute snmpwalk on one of the OIDs:
admin@vlab-01:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 iso.3.6.1.2.1.2.2.1.2
iso.3.6.1.2.1.2.2.1.2.1 = STRING: "fortyGigE0/0"
iso.3.6.1.2.1.2.2.1.2.5 = STRING: "fortyGigE0/4"
iso.3.6.1.2.1.2.2.1.2.9 = STRING: "fortyGigE0/8"
iso.3.6.1.2.1.2.2.1.2.13 = STRING: "fortyGigE0/12"
iso.3.6.1.2.1.2.2.1.2.17 = STRING: "fortyGigE0/16"
iso.3.6.1.2.1.2.2.1.2.21 = STRING: "fortyGigE0/20"
iso.3.6.1.2.1.2.2.1.2.25 = STRING: "fortyGigE0/24"
iso.3.6.1.2.1.2.2.1.2.29 = STRING: "fortyGigE0/28"
..
iso.3.6.1.2.1.2.2.1.2.10000 = STRING: "eth0"

Tested on multi asic VS; SNMP service starts without any error log.
admin@vlab-08:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 iso.3.6.1.2.1.2.2.1.2
Execute snmpwalk on one of the OIDs:
iso.3.6.1.2.1.2.2.1.2.1 = STRING: "Ethernet1/1"
iso.3.6.1.2.1.2.2.1.2.5 = STRING: "Ethernet1/2"
iso.3.6.1.2.1.2.2.1.2.9 = STRING: "Ethernet1/3"
iso.3.6.1.2.1.2.2.1.2.13 = STRING: "Ethernet1/4"
iso.3.6.1.2.1.2.2.1.2.17 = STRING: "Ethernet1/5"
iso.3.6.1.2.1.2.2.1.2.21 = STRING: "Ethernet1/6"
iso.3.6.1.2.1.2.2.1.2.25 = STRING: "Ethernet1/7"
iso.3.6.1.2.1.2.2.1.2.29 = STRING: "Ethernet1/8"
iso.3.6.1.2.1.2.2.1.2.1001 = STRING: "PortChannel0001"
..
iso.3.6.1.2.1.2.2.1.2.9000 = STRING: "Eth4-ASIC0"
iso.3.6.1.2.1.2.2.1.2.9004 = STRING: "Eth5-ASIC0"
iso.3.6.1.2.1.2.2.1.2.9008 = STRING: "Eth6-ASIC0"
iso.3.6.1.2.1.2.2.1.2.9012 = STRING: "Eth7-ASIC0"
...

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

