### PR TITLE
Remove unnecessary `apt-get purge` after sonic-slave-buster removed these packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,6 @@ stages:
 
     - script: |
         set -ex
-        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
         sudo dpkg -i ../target/debs/buster/{libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb,libhiredis0.14_*.deb}
         sudo python3 -m pip install ../target/python-wheels/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/sonic_py_common-1.0-py3-none-any.whl


### PR DESCRIPTION
**- What I did**
After https://github.com/Azure/sonic-buildimage/pull/8070, this command is not needed anymore.

**- How I did it**

**- How to verify it**

**- Description for the changelog**


