### PR TITLE
Entries under .1.3.6.1.2.1.31.1.1.1.18 OID should return the "description" field of PORT_TABLE entries in APPL_DB or CONFIG_DB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -210,18 +210,8 @@ class InterfaceMIBUpdater(MIBUpdater):
         if not entry:
             return
 
+        # This returns empty values for LAG, vlan & mgmt, which is the expected result
         result = entry.get("description", "")
-        
-        if not result:
-            #RFC2863 tables don't have descriptions for LAG, vlan & mgmt; take from RFC1213
-            oid = self.get_oid(sub_id)
-            if oid in self.oid_lag_name_map:
-                result = self.oid_lag_name_map[oid]
-            elif oid in self.mgmt_oid_name_map:
-                result = self.mgmt_alias_map[self.mgmt_oid_name_map[oid]]
-            elif oid in self.vlan_oid_name_map:
-                result = self.vlan_oid_name_map[oid]
-
         return result
 
     def get_counter32(self, sub_id, table_name):

--- a/tests/namespace/test_interfaces.py
+++ b/tests/namespace/test_interfaces.py
@@ -911,7 +911,8 @@ class TestGetNextPDU_2863(TestCase):
 
     def test_vlan_iface_ifMIB(self):
         """
-        Test that vlan interface is present in the ifMIB OID path of the MIB
+        Test that vlan interface is present in the ifMIB OID path of the MIB.
+        It is empty because there is no corresponding entry in config DB.
         """
         oid = ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 2999))
         get_pdu = GetNextPDU(
@@ -926,11 +927,12 @@ class TestGetNextPDU_2863(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))))
-        self.assertEqual(str(value0.data), 'Vlan1000')
+        self.assertEqual(str(value0.data), '')
 
     def test_vlan_iface_description_ifMIB(self):
         """
-        Test vlan interface description (which is simply the name) in the ifMIB OID path of the MIB
+        Test vlan interface description in the ifMIB OID path of the MIB.
+        It is empty because there is no corresponding entry in config DB.
         """
         oid = ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))
         get_pdu = GetPDU(
@@ -945,6 +947,6 @@ class TestGetNextPDU_2863(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))))
-        self.assertEqual(str(value0.data), 'Vlan1000')
+        self.assertEqual(str(value0.data), '')
 
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -914,7 +914,8 @@ class TestGetNextPDU_2863(TestCase):
 
     def test_vlan_iface_ifMIB(self):
         """
-        Test that vlan interface is present in the ifMIB OID path of the MIB
+        Test that vlan interface is present in the ifMIB OID path of the MIB.
+        It is empty because there is no corresponding entry in config DB.
         """
         oid = ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 2999))
         get_pdu = GetNextPDU(
@@ -929,11 +930,12 @@ class TestGetNextPDU_2863(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))))
-        self.assertEqual(str(value0.data), 'Vlan1000')
+        self.assertEqual(str(value0.data), '')
 
     def test_vlan_iface_description_ifMIB(self):
         """
-        Test vlan interface description (which is simply the name) in the ifMIB OID path of the MIB
+        Test vlan interface description in the ifMIB OID path of the MIB.
+        It is empty because there is no corresponding entry in config DB.
         """
         oid = ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))
         get_pdu = GetPDU(
@@ -948,7 +950,7 @@ class TestGetNextPDU_2863(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 3000))))
-        self.assertEqual(str(value0.data), 'Vlan1000')
+        self.assertEqual(str(value0.data), '')
 
     def test_vlan_iface_1213_2863_consistent(self):
         """


### PR DESCRIPTION
**- What I did**

This is a correction of https://github.com/Azure/sonic-snmpagent/pull/218, which is contained in https://github.com/Azure/sonic-buildimage/pull/7859, after community decided that entries under .1.3.6.1.2.1.31.1.1.1.18 OID should return the "description" field of PORT_TABLE entries in APPL_DB or CONFIG_DB.  For vlan, management and LAG, these are empty strings.

**- How I did it**

Deleted the lines of code quoted by Suvarna in the above PRs.  This necessitated modifying 4 unit tests that had been written under the assumption that these OIDs would return non-empty data.

**- How to verify it**

Run unit tests in build and snmp tests in sonic-mgmt.

**- Description for the changelog**

Entries under .1.3.6.1.2.1.31.1.1.1.18 OID should return the "description" field of PORT_TABLE entries in APPL_DB or CONFIG_DB.

