### PR TITLE
Fix: SonicV2Connector behavior change: get_all will return empty dict if the hash does not exist in Redis

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -79,7 +79,7 @@ class ArpUpdater(MIBUpdater):
             neigh_str = neigh_key
             db_index = self.neigh_key_list[neigh_key]
             neigh_info = self.db_conn[db_index].get_all(mibs.APPL_DB, neigh_key, blocking=False)
-            if neigh_info is None:
+            if not neigh_info:
                 continue
             ip_family = neigh_info['family']
             if ip_family == "IPv4":

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -65,7 +65,7 @@ class RouteUpdater(MIBUpdater):
                 continue
             port_table = multi_asic.get_port_table_for_asic(db_conn.namespace)
             ent = db_conn.get_all(mibs.APPL_DB, route_str, blocking=False)
-            if ent is None:
+            if not ent:
                 continue
             nexthops = ent["nexthop"]
             ifnames = ent["ifname"]


### PR DESCRIPTION
**- What I did**
Fixes https://github.com/Azure/sonic-buildimage/issues/8140

ref: swsssdk implementation returns None, and the library will be deprecated
     libswsscommon implementation returns empty dict

**- How I did it**
Relax the condition check to accept both representations

**- How to verify it**
Unit test

**- Description for the changelog**
