### PR TITLE
[RFC1213]: Initialize lag oid map in reinit_data

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -235,6 +235,11 @@ class InterfacesUpdater(MIBUpdater):
         self.rif_port_map, \
         self.port_rif_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_rif_tables, self.db_conn)
 
+        self.lag_name_if_name_map, \
+        self.if_name_lag_name_map, \
+        self.oid_lag_name_map, \
+        self.lag_sai_map, self.sai_lag_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
+
     def update_data(self):
         """
         Update redis (caches config)
@@ -245,11 +250,6 @@ class InterfacesUpdater(MIBUpdater):
         self.update_rif_counters()
 
         self.aggregate_counters()
-
-        self.lag_name_if_name_map, \
-        self.if_name_lag_name_map, \
-        self.oid_lag_name_map, \
-        self.lag_sai_map, self.sai_lag_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
 
         self.if_range = sorted(list(self.oid_name_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Initialize lag oid map in reinit_data instead of
updating in update_data. Updating lag oid map in update_data
can cause descrepancy as interface oid map is updated in
reinit_data.

There could be a scenario when lag oid map has lag oids updated in update_data but interfaces oid map is not updated as interfaces oid map is updated in reinit_data. When SNMP service comes up, there could be a short instance of time when interfaces oid map (oid_sai_map) is empty or not complete but lag oid map (oid_lag_name_map) is updated with lag oids and lag members. At this short span, if a SNMP query is done to get interfaces counters, current code will try to get LAG counters and will fail at https://github.com/Azure/sonic-snmpagent/blob/master/src/sonic_ax_impl/mibs/ietf/rfc1213.py#L383 when trying to get oid of lag members' oid. This can lead to key error : sai_id = self.oid_sai_map[oid]#012KeyError.
This change is to avoid this scenario.

**- How I did it**
init_sync_d_lag_tables in reinit_data instead of invoking in update_data.

**- How to verify it**
unit-test pass.
SNMP walk of interface MIB output is complete.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

