### PR TITLE
[rfc2737]: Handle unicode error when parsing transceiver

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -55,7 +55,7 @@ def get_transceiver_data(xcvr_info):
     result = tuple()
     for xcvr_field in XcvrInfoDB:
         try:
-            result = result +  (xcvr_info.get(xcvr_field.value, b"").decode(),)
+            result = result + (xcvr_info.get(xcvr_field.value, b"").decode(),)
         except UnicodeError:
             result = result + ("",)
     return result

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -52,10 +52,13 @@ def get_transceiver_data(xcvr_info):
     :return: tuple (type, hw_version, mfg_name, model_name) of transceiver;
     Empty string if field not in xcvr_info
     """
-
-    return (xcvr_info.get(xcvr_field.value, b"").decode()
-            for xcvr_field in XcvrInfoDB)
-
+    result = tuple()
+    for xcvr_field in XcvrInfoDB:
+        try:
+            result = result +  (xcvr_info.get(xcvr_field.value, b"").decode(),)
+        except UnicodeError:
+            result = result + ("",)
+    return result
 
 def get_transceiver_description(sfp_type, if_alias):
     """

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -94,6 +94,11 @@ class SwssSyncClient(mockredis.MockRedis):
 
         with open(fname) as f:
             js = json.load(f)
+            # Add a corrupted string to test decoding of corrupted string.
+            # If this corrupted string is added in json file, 
+            # json.load throws an exception.
+            if u'TRANSCEIVER_INFO|Ethernet4' in js and u'hardware_rev' in js[u'TRANSCEIVER_INFO|Ethernet4']:
+                js[u'TRANSCEIVER_INFO|Ethernet4'][u'hardware_rev'] = b'\xff\xff'
             for h, table in js.items():
                 for k, v in table.items():
                     self.hset(h, k, v)

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -26,7 +26,7 @@
   },
   "TRANSCEIVER_INFO|Ethernet4": {
     "type": "QSFP+",
-    "hardware_rev": "\xff\xff",
+    "hardware_rev": "\\xff\\xff",
     "serial": "SERIAL_NUM_2",
     "manufacturer": "VENDOR_NAME_2",
     "model": "MODEL_NAME_2"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -24,6 +24,13 @@
     "manufacturer": "VENDOR_NAME",
     "model": "MODEL_NAME"
   },
+  "TRANSCEIVER_INFO|Ethernet4": {
+    "type": "QSFP+",
+    "hardware_rev": ""\xff\xff",
+    "serial": "SERIAL_NUM_2",
+    "manufacturer": "VENDOR_NAME_2",
+    "model": "MODEL_NAME_2"
+  },
   "TRANSCEIVER_DOM_SENSOR|Ethernet0": {
     "temperature": 25.39,
     "voltage": 3.37,

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -26,7 +26,7 @@
   },
   "TRANSCEIVER_INFO|Ethernet4": {
     "type": "QSFP+",
-    "hardware_rev": ""\xff\xff",
+    "hardware_rev": "\xff\xff",
     "serial": "SERIAL_NUM_2",
     "manufacturer": "VENDOR_NAME_2",
     "model": "MODEL_NAME_2"


### PR DESCRIPTION
data.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If there is an issue in transceiver data and some junk characters are present in transceiver data, then SNMP does not parse this information and transceiver MIB cannot be queried.
Error seen in such scenario:
```
show interface transceiver eeprom
...
Ethernet5: SFP EEPROM detected
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Unknown
        Extended RateSelect Compliance: Unknown
        Identifier: Unknown
        Length Cable Assembly(m): 255
        Length OM1(m): 255
        Length OM2(m): 255
        Length OM3(2m): 255
        Length(km): 255
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: 10GBase-LR
                Fibre Channel Speed: 100 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: AAA
                Fibre Channel transmission media: AAA
                Gigabit Ethernet Compliant codes: 1000BASE-CX
                SAS/SATA compliance codes: AAA
                SONET Compliance codes: AAA
        Vendor Date Code(YYYY-MM-DD Lot): 20ÿÿ-ÿÿ-ÿÿ ÿÿ
        Vendor Name: ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
        Vendor OUI: AAA
        Vendor PN: ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
        Vendor Rev: ÿÿ
        Vendor SN: ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ

Error log in syslog:
INFO snmp#supervisord: snmp-subagent ERROR:ax_interface:MIBUpdater.start() caught an unexpected exception during update_data()
INFO snmp#supervisord: snmp-subagent Traceback (most recent call last):
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start
INFO snmp#supervisord: snmp-subagent     self.reinit_data()
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 192, in reinit_data
INFO snmp#supervisord: snmp-subagent     self._update_transceiver_cache(interface)
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 276, in _update_transceiver_cache
INFO snmp#supervisord: snmp-subagent     self.physical_model_name_map[sub_id] = get_transceiver_data(transceiver_info)
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 76, in <genexpr>
INFO snmp#supervisord: snmp-subagent     for xcvr_field in XcvrInfoDB)

Because of this xcvr MIB does not provide expected output:
iso.3.6.1.2.1.47.1.1.1.1.13.5000 = No Such Instance currently exists at this OID
```
To avoid seeing this error message and to retrieve the transceiver information that is available in SNMP output, this fix is made.

**- How I did it**
Handle unicode error to handle parsing error seen in snmp_ax_impl.

**- How to verify it**
In the device where the above error was seen, fix was made and tested.
- No error message in syslog.
- Able to retrieve xcvr information using OID: iso.3.6.1.2.1.47.1.1.1.1

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

