### PR TITLE
Fix: LAG counters, if LAG don't have L3 interface

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -410,7 +410,7 @@ class InterfacesUpdater(MIBUpdater):
             # self.lag_sai_map['PortChannel01'] = '2000000000006'
             # self.port_rif_map['2000000000006'] = '6000000000006'
             sai_lag_id = self.lag_sai_map[self.oid_lag_name_map[oid]]
-            sai_lag_rif_id = self.port_rif_map[sai_lag_id]
+            sai_lag_rif_id = self.port_rif_map[sai_lag_id] if sai_lag_id in self.port_rif_map else None
             if sai_lag_rif_id in self.rif_port_map:
                 # Extract the 'name' part of 'table_name'.
                 # Example: 


### PR DESCRIPTION
**- What I did**
A KeyError exception raised in rfc1213.py if LAG port don't have L3 interface
````
Oct 25 14:10:29.864852 sonic ERR snmp#snmp-subagent [ax_interface] ERROR: SubtreeMIBEntry.__call__() caught an unexpected exception during _callable_.__call__()
#012Traceback (most recent call last):
#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 194, in __call__
#012    return self._callable_.__call__(sub_id, *self._callable_args)
#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 413, in get_counter
#012    sai_lag_rif_id = self.port_rif_map[sai_lag_id]#012KeyError: '20000000007c2'
````

**- How I did it**
Checked if sai_lag_id is contained in port_rif_map

**- How to verify it**
Build docker-snmp. No exception is observed.

**- Description for the changelog**

