### PR TITLE
Fix Queue stat unavailable error seen during SNMP service start

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -44,7 +44,6 @@ RIF_DROPS_AGGR_MAP = {
 
 redis_kwargs = {'unix_socket_path': '/var/run/redis/redis.sock'}
 
-
 def get_neigh_info(neigh_key):
     """
     split neigh_key string of the format:
@@ -456,8 +455,13 @@ def init_sync_d_queue_tables(db_conn):
         logger.debug("Counters DB does not contain ports")
         return {}, {}, {}
     elif not queue_stat_map:
-        logger.error("No queue stat counters found in the Counter DB. SyncD database is incoherent.")
-        raise RuntimeError('The queue_stat_map is not defined')
+        init_sync_d_queue_tables.error_counter += 1
+        if init_sync_d_queue_tables.error_counter > 3:
+            logger.error("No queue stat counters found in the Counter DB. SyncD database is incoherent.")
+            raise RuntimeError('The queue_stat_map is not defined')
+        else:
+            logger.debug("No queue stat counters found in the Counter DB. Wait to be updated.")
+            return {}, {}, {}
 
     for queues in port_queue_list_map.values():
         queues.sort()

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -454,14 +454,9 @@ def init_sync_d_queue_tables(db_conn):
     if not port_queues_map:
         logger.debug("Counters DB does not contain ports")
         return {}, {}, {}
-    elif not queue_stat_map:
-        init_sync_d_queue_tables.error_counter += 1
-        if init_sync_d_queue_tables.error_counter > 3:
-            logger.error("No queue stat counters found in the Counter DB. SyncD database is incoherent.")
-            raise RuntimeError('The queue_stat_map is not defined')
-        else:
-            logger.debug("No queue stat counters found in the Counter DB. Wait to be updated.")
-            return {}, {}, {}
+    if not queue_stat_map:
+        logger.debug("No queue stat counters found in the Counter DB.")
+        return {}, {}, {}
 
     for queues in port_queue_list_map.values():
         queues.sort()

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -66,7 +66,6 @@ class QueueStatUpdater(MIBUpdater):
         self.queue_type_map = {}
         self.port_index_namespace = {}
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
-        mibs.init_sync_d_queue_tables.error_counter = 0
 
     def reinit_data(self):
         """

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -66,6 +66,7 @@ class QueueStatUpdater(MIBUpdater):
         self.queue_type_map = {}
         self.port_index_namespace = {}
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
+        mibs.init_sync_d_queue_tables.error_counter = 0
 
     def reinit_data(self):
         """

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -3,6 +3,7 @@ import sys
 from unittest import TestCase
 
 import tests.mock_tables.dbconnector
+from sonic_ax_impl import mibs
 
 if sys.version_info.major == 3:
     from unittest import mock
@@ -50,3 +51,14 @@ class TestGetNextPDU(TestCase):
         self.assertTrue(if_alias_map == {})
         self.assertTrue(if_id_map == {})
         self.assertTrue(oid_name_map == {})
+
+    @mock.patch('swsssdk.dbconnector.SonicV2Connector.get_all', mock.MagicMock(return_value=({})))
+    def test_init_sync_d_queue_tables(self):
+        mock_queue_stat_map = {}
+        db_conn = Namespace.init_namespace_dbs()
+
+        port_queues_map, queue_stat_map, port_queue_list_map = \
+            Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_queue_tables, db_conn)
+        self.assertTrue(port_queues_map == {})
+        self.assertTrue(queue_stat_map == {})
+        self.assertTrue(port_queue_list_map == {})


### PR DESCRIPTION
subagent comes up. Do not flag runtime error if queue stat
counter is not found in the first 3 update iterations.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ideally SNMP service starts only after swss/syncd comes up.
But due to timing of bring up, It could happen that SNMP is trying to retrieve queue stat counter before it is update by syncd.
This is only seen once when the SNMP service comes up, as from the next iteration, syncd has updated the queue stats and it is available for SNMP to use.
 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: No queue stat counters found in the Counter DB. SyncD database is incoherent.
 This message is seen only once in all the cases observed, which means that once the counters are populated, snmp is able to retrieve the counters.
**- How I did it**
If counters are not found, return empty dicts since SNMP is just supposed to collect data and provide the data it has.

**- How to verify it**
Added unit-test.
If counters_db is not update, querying the QueueStats MIB should not return any output.
Sample output if there are no counters:
```
admin@vlab-01:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 1.3.6.1.4.1.9.9.580.1.5.5.1.4
iso.3.6.1.4.1.9.9.580.1.5.5.1.4 = No Such Object available on this agent at this OID
```
Output on VS with the diff in the PR :
```
admin@vlab-01:~$ docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 1.3.6.1.4.1.9.9.580.1.5.5.1.4
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.1 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.2 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.3 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.4 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.5 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.6 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.7 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.1.8 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.1 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.2 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.3 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.4 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.5 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.6 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.7 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.2.8 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.3.1 = Counter64: 0
iso.3.6.1.4.1.9.9.580.1.5.5.1.4.1.2.3.2 = Counter64: 0
..
``
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

