### PR TITLE
Fix RFC2737 implementation with updated xcvr vendor version key name

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -96,7 +96,7 @@ class XcvrInfoDB(str, Enum):
     Transceiver info keys
     """
     TYPE              = "type"
-    HARDWARE_REVISION = "hardware_rev"
+    VENDOR_REVISION   = "vendor_rev"
     SERIAL_NUMBER     = "serial"
     MANUFACTURE_NAME  = "manufacturer"
     MODEL_NAME        = "model"

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -1,7 +1,7 @@
 {
   "TRANSCEIVER_INFO|Ethernet0": {
     "type": "QSFP+",
-    "hardware_rev": "A1",
+    "vendor_rev": "A1",
     "serial": "SERIAL_NUM",
     "manufacturer": "VENDOR_NAME",
     "model": "MODEL_NAME"

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -1,7 +1,7 @@
 {
   "TRANSCEIVER_INFO|Ethernet8": {
     "type": "QSFP+",
-    "hardware_rev": "A1",
+    "vendor_rev": "A1",
     "serial": "SERIAL_NUM",
     "manufacturer": "VENDOR_NAME",
     "model": "MODEL_NAME"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -34,7 +34,7 @@
   },
   "TRANSCEIVER_INFO|Ethernet0": {
     "type": "QSFP+",
-    "hardware_rev": "A1",
+    "vendor_rev": "A1",
     "serial": "SERIAL_NUM",
     "manufacturer": "VENDOR_NAME",
     "model": "MODEL_NAME",
@@ -42,7 +42,7 @@
   },
   "TRANSCEIVER_INFO|Ethernet1": {
     "type": "QSFP-DD",
-    "hardware_rev": "A1",
+    "vendor_rev": "A1",
     "serial": "SERIAL_NUM",
     "manufacturer": "VENDOR_NAME",
     "model": "MODEL_NAME",


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

In the TRANSCEIVER_INFO table of STATE_DB, the key of transceiver reversion was changed from "hardware_rev" to "vendor_rev", detail info please refer to PR https://github.com/Azure/sonic-platform-daemons/pull/231

SNMP needs to be updated with the updated key name in order to get the correct info from the state DB

**- How I did it**

Update the key name from "hardware_rev" to "vendor_rev", update the unit test cases.

**- How to verify it**

Run the community SNMP test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

