### PR TITLE
Add VoQ Recirc interface (i.e., Ethernet-Rec) to interface maps for S…

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -275,7 +275,8 @@ def init_sync_d_interface_tables(db_conn):
         if_name_str = if_name
         if (re.match(port_util.SONIC_ETHERNET_RE_PATTERN, if_name_str) or \
                 re.match(port_util.SONIC_ETHERNET_BP_RE_PATTERN, if_name_str) or \
-                re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name_str)):
+                re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name_str) or \
+                re.match(port_util.SONIC_ETHERNET_REC_RE_PATTERN, if_name_str)):
             if_name_map[if_name] = sai_id
     # As sai_id is not unique in multi-asic platform, concatenate it with
     # namespace to get a unique key. Assuming that ':' is not present in namespace
@@ -284,7 +285,8 @@ def init_sync_d_interface_tables(db_conn):
     for sai_id, if_name in if_id_map_util.items():
         if (re.match(port_util.SONIC_ETHERNET_RE_PATTERN, if_name) or \
                 re.match(port_util.SONIC_ETHERNET_BP_RE_PATTERN, if_name) or \
-                re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name)):
+                re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name) or \
+                re.match(port_util.SONIC_ETHERNET_REC_RE_PATTERN, if_name)):
             if_id_map[get_sai_id_key(db_conn.namespace, sai_id)] = if_name
     logger.debug("Port name map:\n" + pprint.pformat(if_name_map, indent=2))
     logger.debug("Interface name map:\n" + pprint.pformat(if_id_map, indent=2))

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -56,6 +56,16 @@
     "alias": "etp4",
     "speed": 100000
   },
+  "PORT_TABLE:Ethernet-IB0": {
+    "description": "inband",
+    "alias": "rec0",
+    "speed": 100000
+  },
+  "PORT_TABLE:Ethernet-Rec0": {
+    "description": "recirc",
+    "alias": "rec1",
+    "speed": 100000
+  },
   "ROUTE_TABLE:0.0.0.0/0": {
     "ifname": "Ethernet0,Ethernet4",
     "nexthop": "10.0.0.1,10.0.0.3"

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -27,6 +27,18 @@
     "role": "Int",
     "speed": 100000
   },
+  "PORT_TABLE:Ethernet-IB0": {
+    "description": "inband",
+    "alias": "rec0",
+    "role": "Inb",
+    "speed": 100000
+  },
+  "PORT_TABLE:Ethernet-Rec0": {
+    "description": "recirc",
+    "alias": "rec1",
+    "role": "Rec",
+    "speed": 100000
+  },
   "LAG_MEMBER_TABLE:PortChannel01:Ethernet-BP0": {
     "status": "enabled"
   },

--- a/tests/mock_tables/asic0/counters_db.json
+++ b/tests/mock_tables/asic0/counters_db.json
@@ -311,7 +311,7 @@
     "Ethernet-BP0": "oid:0x1000000000005",
     "Ethernet-BP4": "oid:0x1000000000006",
     "Ethernet-IB0": "oid:0x1000000000007",
-    "Ethernet-Rec0": "oid:0x1000000000008",
+    "Ethernet-Rec0": "oid:0x1000000000008"
   },
   "COUNTERS_LAG_NAME_MAP": {
     "PortChannel01": "oid:0x1000000000007"

--- a/tests/mock_tables/asic0/counters_db.json
+++ b/tests/mock_tables/asic0/counters_db.json
@@ -309,7 +309,9 @@
     "Ethernet0": "oid:0x1000000000003",
     "Ethernet4": "oid:0x1000000000004",
     "Ethernet-BP0": "oid:0x1000000000005",
-    "Ethernet-BP4": "oid:0x1000000000006"
+    "Ethernet-BP4": "oid:0x1000000000006",
+    "Ethernet-IB0": "oid:0x1000000000007",
+    "Ethernet-Rec0": "oid:0x1000000000008",
   },
   "COUNTERS_LAG_NAME_MAP": {
     "PortChannel01": "oid:0x1000000000007"

--- a/tests/mock_tables/asic0/counters_db.json
+++ b/tests/mock_tables/asic0/counters_db.json
@@ -310,8 +310,8 @@
     "Ethernet4": "oid:0x1000000000004",
     "Ethernet-BP0": "oid:0x1000000000005",
     "Ethernet-BP4": "oid:0x1000000000006",
-    "Ethernet-IB0": "oid:0x1000000000007",
-    "Ethernet-Rec0": "oid:0x1000000000008"
+    "Ethernet-IB0": "oid:0x1000000000080",
+    "Ethernet-Rec0": "oid:0x1000000000081"
   },
   "COUNTERS_LAG_NAME_MAP": {
     "PortChannel01": "oid:0x1000000000007"

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -49,8 +49,8 @@ class TestGetNextPDU(TestCase):
         print(str(if_id_map))
         print(str(oid_name_map))
         for recirc_port_name, sai_id, intf_alias, intf_id_key, intf_index in [
-              ('Ethernet-IB0', '1000000000007', 'rec0', 'asic0:1000000000007', BaseIdx.ethernet_ib_base_idx),
-              ('Ethernet-Rec0', '1000000000008', 'rec1', 'asic0:1000000000008', BaseIdx.ethernet_rec_base_idx)]:
+              ('Ethernet-IB0',  '1000000000080', 'rec0', 'asic0:1000000000080', BaseIdx.ethernet_ib_base_idx),
+              ('Ethernet-Rec0', '1000000000081', 'rec1', 'asic0:1000000000081', BaseIdx.ethernet_rec_base_idx)]:
             self.assertTrue(if_name_map[recirc_port_name] == sai_id)
             self.assertTrue(if_alias_map[recirc_port_name] == intf_alias)
             self.assertTrue(oid_name_map[intf_index] == recirc_port_name)

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -52,7 +52,7 @@ class TestGetNextPDU(TestCase):
               ('Ethernet-Rec0', '1000000000008', 'rec1', 'asic0:1000000000008', port_util.BaseIdx.ethernet_rec_base_idx)]:
             self.assertTrue(if_name_map[recirc_port_name] == sai_id)
             self.assertTrue(if_alias_map[recirc_port_name] == intf_alias)
-            self.assertTrue(oid_name_map[intf_index] == recirc_port_name)]
+            self.assertTrue(oid_name_map[intf_index] == recirc_port_name)
             self.assertTrue(if_id_map[intf_id_key] == recirc_port_name)
 
     @classmethod

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -10,6 +10,7 @@ modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from sonic_ax_impl import mibs
+from swsssdk.port_util import BaseIdx
 
 class TestGetNextPDU(TestCase):
     @classmethod
@@ -48,8 +49,8 @@ class TestGetNextPDU(TestCase):
         print(str(if_id_map))
         print(str(oid_name_map))
         for recirc_port_name, sai_id, intf_alias, intf_id_key, intf_index in [
-              ('Ethernet-IB0', '1000000000007', 'rec0', 'asic0:1000000000007', port_util.BaseIdx.ethernet_ib_base_idx),
-              ('Ethernet-Rec0', '1000000000008', 'rec1', 'asic0:1000000000008', port_util.BaseIdx.ethernet_rec_base_idx)]:
+              ('Ethernet-IB0', '1000000000007', 'rec0', 'asic0:1000000000007', BaseIdx.ethernet_ib_base_idx),
+              ('Ethernet-Rec0', '1000000000008', 'rec1', 'asic0:1000000000008', BaseIdx.ethernet_rec_base_idx)]:
             self.assertTrue(if_name_map[recirc_port_name] == sai_id)
             self.assertTrue(if_alias_map[recirc_port_name] == intf_alias)
             self.assertTrue(oid_name_map[intf_index] == recirc_port_name)

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -43,10 +43,17 @@ class TestGetNextPDU(TestCase):
         if_alias_map, \
         if_id_map, \
         oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, db_conn)
+        print(str(if_name_map))
+        print(str(if_alias_map))
+        print(str(if_id_map))
+        print(str(oid_name_map))
         for recirc_port_name, sai_id in [('Ethernet-IB0', 0), ('Ethernet-Rec0', 1)]:
             self.assertTrue(if_name_map[recirc_port_name] == sai_id)
-            self.assertTrue(if_id_map[sai_id] == recirc_port_name)            
-        
+            self.assertTrue(if_id_map[sai_id] == recirc_port_name)
+        for oid, recirc_port_name in [('0x1000000000007', 'Ethernet-IB0'),
+                                      ('0x1000000000008', 'Ethernet-Rec0')]:
+            self.assertTrue(oid_name_map[oid] == recirc_port_name)
+
     @classmethod
     def tearDownClass(cls):
         tests.mock_tables.dbconnector.clean_up_config()

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -44,10 +44,6 @@ class TestGetNextPDU(TestCase):
         if_alias_map, \
         if_id_map, \
         oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, db_conn)
-        print(str(if_name_map))
-        print(str(if_alias_map))
-        print(str(if_id_map))
-        print(str(oid_name_map))
         for recirc_port_name, sai_id, intf_alias, intf_id_key, intf_index in [
               ('Ethernet-IB0',  '1000000000080', 'rec0', 'asic0:1000000000080', BaseIdx.ethernet_ib_base_idx),
               ('Ethernet-Rec0', '1000000000081', 'rec1', 'asic0:1000000000081', BaseIdx.ethernet_rec_base_idx)]:

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -36,6 +36,17 @@ class TestGetNextPDU(TestCase):
         self.assertTrue("PortChannel_Temp" in lag_name_if_name_map)
         self.assertTrue(lag_name_if_name_map["PortChannel_Temp"] == [])
 
+    def test_init_sync_d_interface_tables_for_recirc_ports(self):
+        db_conn = Namespace.init_namespace_dbs()
+
+        if_name_map, \
+        if_alias_map, \
+        if_id_map, \
+        oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, db_conn)
+        for recirc_port_name, sai_id in [('Ethernet-IB0', 0), ('Ethernet-Rec0', 1)]:
+            self.assertTrue(if_name_map[recirc_port_name] == sai_id)
+            self.assertTrue(if_id_map[sai_id] == recirc_port_name)            
+        
     @classmethod
     def tearDownClass(cls):
         tests.mock_tables.dbconnector.clean_up_config()

--- a/tests/namespace/test_mibs.py
+++ b/tests/namespace/test_mibs.py
@@ -47,12 +47,13 @@ class TestGetNextPDU(TestCase):
         print(str(if_alias_map))
         print(str(if_id_map))
         print(str(oid_name_map))
-        for recirc_port_name, sai_id in [('Ethernet-IB0', 0), ('Ethernet-Rec0', 1)]:
+        for recirc_port_name, sai_id, intf_alias, intf_id_key, intf_index in [
+              ('Ethernet-IB0', '1000000000007', 'rec0', 'asic0:1000000000007', port_util.BaseIdx.ethernet_ib_base_idx),
+              ('Ethernet-Rec0', '1000000000008', 'rec1', 'asic0:1000000000008', port_util.BaseIdx.ethernet_rec_base_idx)]:
             self.assertTrue(if_name_map[recirc_port_name] == sai_id)
-            self.assertTrue(if_id_map[sai_id] == recirc_port_name)
-        for oid, recirc_port_name in [('0x1000000000007', 'Ethernet-IB0'),
-                                      ('0x1000000000008', 'Ethernet-Rec0')]:
-            self.assertTrue(oid_name_map[oid] == recirc_port_name)
+            self.assertTrue(if_alias_map[recirc_port_name] == intf_alias)
+            self.assertTrue(oid_name_map[intf_index] == recirc_port_name)]
+            self.assertTrue(if_id_map[intf_id_key] == recirc_port_name)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
…yncD-connected MIB(s)



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

VoQ inband port support was added in https://github.com/Azure/sonic-snmpagent/pull/228. This PR is to add support for VoQ recirc port.

This PR depends https://github.com/Azure/sonic-py-swsssdk/pull/118, which defines index for VoQ recirc port.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

