### PR TITLE
Handle error seen on system where vlan interface map is not present

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -337,7 +337,11 @@ def init_sync_d_vlan_tables(db_conn):
     :return: tuple(vlan_name_map, oid_sai_map, oid_name_map)
     """
 
-    vlan_name_map = port_util.get_vlan_interface_oid_map(db_conn)
+    vlan_name_map = port_util.get_vlan_interface_oid_map(db_conn, blocking=False)
+
+    if not vlan_name_map:
+        logger.debug("There is no vlan interface map in counters DB")
+        return {}, {}, {}
 
     logger.debug("Vlan oid map:\n" + pprint.pformat(vlan_name_map, indent=2))
 

--- a/tests/test_mibs.py
+++ b/tests/test_mibs.py
@@ -62,3 +62,15 @@ class TestGetNextPDU(TestCase):
         self.assertTrue(port_queues_map == {})
         self.assertTrue(queue_stat_map == {})
         self.assertTrue(port_queue_list_map == {})
+
+    @mock.patch('swsssdk.dbconnector.SonicV2Connector.get_all', mock.MagicMock(return_value=({})))
+    def test_init_sync_d_vlan_tables(self):
+        db_conn = Namespace.init_namespace_dbs()
+
+        vlan_name_map, \
+        vlan_oid_sai_map, \
+        vlan_oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_vlan_tables, db_conn)
+
+        self.assertTrue(vlan_name_map == {})
+        self.assertTrue(vlan_oid_sai_map == {})
+        self.assertTrue(vlan_oid_name_map == {})


### PR DESCRIPTION
in counters db.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fixes https://github.com/Azure/sonic-buildimage/issues/9996
Handle error seen on system where vlan interface map is not present.
This change requires: https://github.com/Azure/sonic-py-swsssdk/pull/117
On chassis platform, on supervisor there are not ports available in config_db. So, there is no vlan interface map in counters db, which causes this error in syslog:
```
ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 37, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 233, in reinit_data#012    self.vlan_oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_vlan_tables, self.db_conn)#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/__init__.py", line 649, in get_sync_d_from_all_namespace#012    ns_tuple = per_namespace_func(db_conn)#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/__init__.py", line 339, in init_sync_d_vlan_tables#012    vlan_name_map = port_util.get_vlan_interface_oid_map(db_conn)#012  File "/usr/local/lib/python3.7/dist-packages/swsssdk/port_util.py", line 167, in get_vlan_interface_oid_map#012    rif_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_RIF_NAME_MAP', blocking=True)#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1751, in get_all#012    return dict(super(SonicV2Connector, self).get_all(db_name, _hash, blocking))#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1708, in get_all#012    return _swsscommon.SonicV2Connector_Native_get_all(self, db_name, _hash, blocking)#012RuntimeError: Key '{COUNTERS_RIF_NAME_MAP}' unavailable in database '{COUNTERS_DB}'
```
**- How I did it**
Return empty dict if vlan interface map is not present in DB.
**- How to verify it**
With this fix, no error in syslog message.
Able to execute other MIB queries on supervisor.
UT passes.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

