### PR TITLE
[RFC2737, RFC3433] Exclude RJ45 port from Entity MIB and Entity sensor MIB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -128,6 +128,8 @@ PSU_SENSOR_POSITION_MAP = {
 
 NOT_AVAILABLE = 'N/A'
 
+RJ45_PORT_TYPE = 'RJ45'
+
 def is_null_str(value):
     """
     Indicate if a string value is null
@@ -747,7 +749,7 @@ class XcvrCacheUpdater(PhysicalEntityCacheUpdater):
         transceiver_info = Namespace.dbs_get_all(self.mib_updater.statedb, mibs.STATE_DB,
                                                  mibs.transceiver_info_table(interface))
 
-        if not transceiver_info:
+        if not transceiver_info or transceiver_info['type'] == RJ45_PORT_TYPE:
             return
 
         # update xcvr info from DB

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -422,12 +422,14 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
                      in STATE_DB, skipping".format(transceiver_dom_entry))
                 continue
 
+            # skip RJ45 port
+            transceiver_info_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, mibs.transceiver_info_table(interface))
+            if  transceiver_info_entry_data['type'] == RJ45_PORT_TYPE:
+                continue
+
             # get transceiver sensors from transceiver dom entry in STATE DB
             transceiver_dom_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, transceiver_dom_entry)
-
-            transceiver_info_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, mibs.transceiver_info_table(interface))
-
-            if not transceiver_dom_entry_data or transceiver_info_entry_data['type'] == RJ45_PORT_TYPE:
+            if not transceiver_dom_entry_data:
                 continue
 
             sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry_data)

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -23,7 +23,7 @@ from .sensor_data import ThermalSensorData, FANSensorData, PSUSensorData, Transc
 NOT_AVAILABLE = 'N/A'
 CHASSIS_NAME_SUB_STRING = 'chassis'
 PSU_NAME_SUB_STRING = 'PSU'
-
+RJ45_PORT_TYPE = 'RJ45'
 
 def is_null_empty_str(value):
     """
@@ -425,7 +425,9 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
             # get transceiver sensors from transceiver dom entry in STATE DB
             transceiver_dom_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, transceiver_dom_entry)
 
-            if not transceiver_dom_entry_data:
+            transceiver_info_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, mibs.transceiver_info_table(interface))
+
+            if not transceiver_dom_entry_data or transceiver_info_entry_data['type'] == RJ45_PORT_TYPE:
                 continue
 
             sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry_data)

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -64,6 +64,30 @@
     "tx3power": -5.4,
     "tx4power": -5.4
   },
+  "TRANSCEIVER_INFO|Ethernet2": {
+    "type": "RJ45",
+    "hardware_rev": "N/A",
+    "serial": "N/A",
+    "manufacturer": "N/A",
+    "model": "N/A",
+    "is_replaceable": "N/A"
+  },
+  "TRANSCEIVER_DOM_SENSOR|Ethernet2": {
+    "temperature": "N/A",
+    "voltage": "N/A",
+    "tx1bias": "N/A",
+    "tx2bias": "N/A",
+    "tx3bias": "N/A",
+    "tx4bias": "N/A",
+    "rx1power": "N/A",
+    "rx2power": "N/A",
+    "rx3power": "N/A",
+    "rx4power": "N/A",
+    "tx1power": "N/A",
+    "tx2power": "N/A",
+    "tx3power": "N/A",
+    "tx4power": "N/A"
+  },
   "MGMT_PORT_TABLE|eth0": {
     "oper_status": "down"
   },

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -66,7 +66,7 @@
   },
   "TRANSCEIVER_INFO|Ethernet2": {
     "type": "RJ45",
-    "hardware_rev": "N/A",
+    "vendor_rev": "N/A",
     "serial": "N/A",
     "manufacturer": "N/A",
     "model": "N/A",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,6 +35,7 @@ class TestSonicMIB(TestCase):
     def setUpClass(cls):
         cls.lut = MIBTable(rfc3433.PhysicalSensorTableMIB)
         cls.IFINDEX = 1
+        cls.RJ45_IFINDEX = 3
         cls.XCVR_SUB_ID = get_transceiver_sub_id(cls.IFINDEX)
         cls.XCVR_CHANNELS = (1, 2, 3, 4)
         cls.PSU_POSITION = 2
@@ -54,7 +55,7 @@ class TestSonicMIB(TestCase):
         return [ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 99, 1, 1, 1, i, sub_id))
                 for i in range(1, 5)]
 
-    def _test_getpdu_sensor(self, sub_id, expected_values):
+    def _test_getpdu_sensor(self, sub_id, expected_values, value_type=ValueType.INTEGER):
         """
         Test case for correctness of transceiver sensor MIB values
         :param sub_id: sub OID of the sensor
@@ -75,7 +76,7 @@ class TestSonicMIB(TestCase):
 
         for index, value in enumerate(response.values):
             self.assertEqual(str(value.name), str(oids[index]))
-            self.assertEqual(value.type_, ValueType.INTEGER)
+            self.assertEqual(value.type_, value_type)
             self.assertEqual(value.data, expected_values[index])
 
     def test_getpdu_xcvr_temperature_sensor(self):
@@ -93,6 +94,21 @@ class TestSonicMIB(TestCase):
 
         self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_TEMP)[0], expected_values)
 
+    def test_getpdu_rj45_temperature_sensor(self):
+        """
+        Test case for correctness of transceiver temperature sensor MIB values
+        """
+
+        expected_values = [
+            None,
+            None,
+            None,
+            None,
+            None
+        ]
+
+        self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.RJ45_IFINDEX, SENSOR_TYPE_TEMP)[0], expected_values, ValueType.NO_SUCH_INSTANCE)
+
     def test_getpdu_xcvr_voltage_sensor(self):
         """
         Test case for correctness of transceiver voltage sensor MIB values
@@ -107,6 +123,21 @@ class TestSonicMIB(TestCase):
         ]
 
         self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_VOLTAGE)[0], expected_values)
+
+    def test_getpdu_rj45_voltage_sensor(self):
+            """
+            Test case for correctness of transceiver voltage sensor MIB values
+            """
+
+            expected_values = [
+                None,
+                None,
+                None,
+                None,
+                None
+            ]
+
+            self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.RJ45_IFINDEX, SENSOR_TYPE_VOLTAGE)[0], expected_values, ValueType.NO_SUCH_INSTANCE)
 
     def test_getpdu_xcvr_rx_power_sensor_minus_infinity(self):
         """
@@ -141,6 +172,22 @@ class TestSonicMIB(TestCase):
         for channel in (2, 3, 4):
             self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_RX_POWER + channel)[0], expected_values)
 
+    def test_getpdu_rj45_rx_power_sensor(self):
+        """
+        Test case for correctness of transceiver rx power sensor MIB values
+        """
+
+        expected_values = [
+            None,
+            None,
+            None,
+            None,
+            None
+        ]
+
+        for channel in (1, 2, 3, 4):
+            self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.RJ45_IFINDEX, SENSOR_TYPE_PORT_RX_POWER + channel)[0], expected_values, ValueType.NO_SUCH_INSTANCE)
+
     def test_getpdu_xcvr_tx_power_sensor(self):
         """
         Test case for correctness of transceiver rx power sensor MIB values
@@ -157,6 +204,22 @@ class TestSonicMIB(TestCase):
         # test for each channel except first, we already test above
         for channel in (1, 2, 3, 4):
             self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_POWER + channel)[0], expected_values)
+
+    def test_getpdu_rj45_tx_power_sensor(self):
+        """
+        Test case for correctness of transceiver tx power sensor MIB values
+        """
+
+        expected_values = [
+            None,
+            None,
+            None,
+            None,
+            None
+        ]
+
+        for channel in (1, 2, 3, 4):
+            self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.RJ45_IFINDEX, SENSOR_TYPE_PORT_TX_POWER + channel)[0], expected_values, ValueType.NO_SUCH_INSTANCE)
 
     def test_getpdu_xcvr_tx_bias_sensor_unknown(self):
         """
@@ -206,6 +269,22 @@ class TestSonicMIB(TestCase):
         # test for each channel
         for channel in (2, 4):
             self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.IFINDEX, SENSOR_TYPE_PORT_TX_BIAS + channel)[0], expected_values)
+
+    def test_getpdu_rj45_tx_bias_sensor(self):
+        """
+        Test case for correctness of transceiver tx bias sensor MIB values
+        """
+
+        expected_values = [
+            None,
+            None,
+            None,
+            None,
+            None
+        ]
+
+        for channel in (2, 4):
+            self._test_getpdu_sensor(get_transceiver_sensor_sub_id(self.RJ45_IFINDEX, SENSOR_TYPE_PORT_TX_BIAS + channel)[0], expected_values, ValueType.NO_SUCH_INSTANCE)
 
     def test_getpdu_psu_temp_sensor(self):
         """

--- a/tests/test_sn.py
+++ b/tests/test_sn.py
@@ -224,6 +224,26 @@ class TestSonicMIB(TestCase):
 
         self._check_getpdu(sub_id, expected_mib)
 
+    def test_getpdu_xcvr_info_port_rj45(self):
+        sub_id = get_transceiver_sub_id(3)[0]
+
+        expected_mib = {
+            2: (ValueType.END_OF_MIB_VIEW, 'None'),
+            4: (ValueType.END_OF_MIB_VIEW, 'None'),
+            5: (ValueType.END_OF_MIB_VIEW, 'None'),
+            6: (ValueType.END_OF_MIB_VIEW, 'None'),
+            7: (ValueType.END_OF_MIB_VIEW, 'None'),
+            8: (ValueType.END_OF_MIB_VIEW, 'None'),
+            9: (ValueType.END_OF_MIB_VIEW, 'None'),
+            10: (ValueType.END_OF_MIB_VIEW, 'None'),
+            11: (ValueType.END_OF_MIB_VIEW, 'None'),
+            12: (ValueType.END_OF_MIB_VIEW, 'None'),
+            13: (ValueType.END_OF_MIB_VIEW, 'None'),
+            16: (ValueType.END_OF_MIB_VIEW, 'None')
+        }
+
+        self._check_getpdu(sub_id, expected_mib)
+
     def test_getpdu_xcvr_dom(self):
         expected_mib = {
             get_transceiver_sensor_sub_id(1, SENSOR_TYPE_TEMP)[0]: "DOM Temperature Sensor for etp1",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

RJ45 port will expose the below info to STATE_DB, since there is NO embedded sensor on RJ45 ports, so Entity MIB and Entity sensor MIB should skip the  TRANSCEIVER_INFO and TRANSCEIVER_DOM_SENSOR DB entries for RJ45 ports.

```
  "TRANSCEIVER_INFO|Ethernet2": {
    "type": "RJ45",
    "vendor_rev": "N/A",
    "serial": "N/A",
    "manufacturer": "N/A",
    "model": "N/A",
    "is_replaceable": "N/A"
  },
  "TRANSCEIVER_DOM_SENSOR|Ethernet2": {
    "temperature": "N/A",
    "voltage": "N/A",
    "tx1bias": "N/A",
    "tx2bias": "N/A",
    "tx3bias": "N/A",
    "tx4bias": "N/A",
    "rx1power": "N/A",
    "rx2power": "N/A",
    "rx3power": "N/A",
    "rx4power": "N/A",
    "tx1power": "N/A",
    "tx2power": "N/A",
    "tx3power": "N/A",
    "tx4power": "N/A"
  }
```
**- How I did it**
Add logic to detect the type of transceiver, skip RJ45 type.

**- How to verify it**
run SNMP test on the platforms with RJ45 ports.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

