### PR TITLE
 LLDPLocalSystemDataUpdater Exception Log Handled

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -126,8 +126,8 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
         Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.loc_chassis_data = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE)
         if self.loc_chassis_data:
-            self.loc_chassis_data['lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data['lldp_loc_sys_cap_supported'])
-            self.loc_chassis_data['lldp_loc_sys_cap_enabled'] = parse_sys_capability(self.loc_chassis_data['lldp_loc_sys_cap_enabled'])
+            self.loc_chassis_data['lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data.get('lldp_loc_sys_cap_supported', ''))
+            self.loc_chassis_data['lldp_loc_sys_cap_enabled'] = parse_sys_capability(self.loc_chassis_data.get('lldp_loc_sys_cap_enabled', ''))
 
     def update_data(self):
         """


### PR DESCRIPTION
Signed-off-by: vkarri <vkarri@contoso.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did**

An exception on LLDPLocalSystemDataUpdater instance is seen when the LOC_CHASSIS_TABLE does not have either lldp_loc_sys_cap_supported or lldp_loc_sys_cap_enabled fields.

Although this does not affect an functionality, the exception log can be avoided.

```
tgn-sonic-n1-l1 ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012 File " /usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 37, in start#012 self.reinit_data ()#012 File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 129, in reinit_data#012 self.loc_chassis_data['lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc _chassis_data['lldp_loc_sys_cap_supported'])#012KeyError: 'lldp_loc_sys_cap_supported'
```
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

