### PR TITLE
[201811] Fix sonic_ax_impl memory leak in LLDPLocManAddrUpdater.

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -295,11 +295,12 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         """
         Subclass update data routine.
         """
+        self.man_addr_list = []
+
         # establish connection to application database.
         self.db_conn.connect(mibs.APPL_DB)
         mgmt_ip_bytes = self.db_conn.get(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE, b'lldp_loc_man_addr')
 
-        self.man_addr_list = []
         if not mgmt_ip_bytes:
             self.mgmt_ip_str = ''
         else:

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -299,6 +299,7 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         self.db_conn.connect(mibs.APPL_DB)
         mgmt_ip_bytes = self.db_conn.get(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE, b'lldp_loc_man_addr')
 
+        self.man_addr_list = []
         if not mgmt_ip_bytes:
             self.mgmt_ip_str = ''
         else:


### PR DESCRIPTION

**- What I did**
        Fix sonic_ax_impl memory leak in LLDPLocManAddrUpdater.

**- How I did it**
        In LLDPLocManAddrUpdater.reinit_data(), reset man_addr_list to empty list before append new data.

**- How to verify it**
        Pass all UT.
        Manually check there is no memory leak.

**- Description for the changelog**
        Fix sonic_ax_impl memory leak in LLDPLocManAddrUpdater.
