### PR TITLE
Fix ConfigDB load config crash with swss-common issue.

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -549,11 +549,11 @@ class Namespace:
         if Namespace.db_config_loaded:
             return
 
+        # Load default config first, because when is_multi_asic() can't get platform info from local config file, is_multi_asic() will connect to ConfigDB for platform information.
+        SonicDBConfig.load_sonic_db_config()
         if multi_asic.is_multi_asic():
             # Load the global config file database_global.json once.
             SonicDBConfig.load_sonic_global_db_config()
-        else:
-            SonicDBConfig.load_sonic_db_config()
 
         Namespace.db_config_loaded = True
 


### PR DESCRIPTION
**- What I did**
    Fix following code issue:
        When sonic-py-common change to use sonic-swss-common, sonic_ax_impl will crash because ConfigDB config load multiple times.

        The reason if this issue is because  multi_asic.is_multi_asic() will try load platform information from local environment variable and machine.conf, but if can't load information from local, is_multi_asic() will initialize default sonic DB config and connect to ConfigDB then read platform information.

**- How I did it**
    Code change to load default config before check multi asic.

**- How to verify it**
    Pass all UT and E2E test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

