### PR TITLE
Fix: not to use blocking get_all() after keys()

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -630,7 +630,7 @@ class Namespace:
         result = {}
         # If there are multiple namespaces, _hash might not be
         # present in all namespace, ignore if not present in a
-        # specfic namespace.
+        # specific namespace.
         if len(dbs) > 1:
             tmp_kwargs = kwargs.copy()
             tmp_kwargs['blocking'] = False
@@ -638,7 +638,7 @@ class Namespace:
             tmp_kwargs = kwargs
         for db_conn in dbs:
             ns_result = db_conn.get_all(db_name, _hash, *args, **tmp_kwargs)
-            if ns_result is not None:
+            if ns_result:
                 result.update(ns_result)
         return result
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -151,14 +151,15 @@ class NextHopUpdater(MIBUpdater):
             ipnstr = routestr[len("ROUTE_TABLE:"):]
             if ipnstr == "0.0.0.0/0":
                 ipn = ipaddress.ip_network(ipnstr)
-                ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, routestr, blocking=True)
-                nexthops = ent["nexthop"]
-                for nh in nexthops.split(','):
-                    # TODO: if ipn contains IP range, create more sub_id here
-                    sub_id = ip2byte_tuple(ipn.network_address)
-                    self.route_list.append(sub_id)
-                    self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
-                    break # Just need the first nexthop
+                ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, routestr, blocking=False)
+                if ent:
+                    nexthops = ent["nexthop"]
+                    for nh in nexthops.split(','):
+                        # TODO: if ipn contains IP range, create more sub_id here
+                        sub_id = ip2byte_tuple(ipn.network_address)
+                        self.route_list.append(sub_id)
+                        self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
+                        break # Just need the first nexthop
 
         self.route_list.sort()
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -79,7 +79,7 @@ class FdbUpdater(MIBUpdater):
                 mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': {}.".format(fdb_str, e))
                 continue
 
-            ent = Namespace.dbs_get_all(self.db_conn, mibs.ASIC_DB, s, blocking=True)
+            ent = Namespace.dbs_get_all(self.db_conn, mibs.ASIC_DB, s, blocking=False)
             # Example output: oid:0x3a000000000608
             bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
             if bridge_port_id not in self.if_bpid_map:


### PR DESCRIPTION
**- What I did**
In a dynamic environment, it is possible that some of the keys may
disappear between invoking keys() and get_all().

Prevent unnecessary timeout of blocking get_all().

**- How I did it**

**- How to verify it**

**- Description for the changelog**

