### PR TITLE
Fix: if routestr does not exist, skip

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -80,6 +80,9 @@ class FdbUpdater(MIBUpdater):
                 continue
 
             ent = Namespace.dbs_get_all(self.db_conn, mibs.ASIC_DB, s, blocking=False)
+            if not ent:
+                continue
+
             # Example output: oid:0x3a000000000608
             bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
             if bridge_port_id not in self.if_bpid_map:


### PR DESCRIPTION
**- What I did**
Follow up https://github.com/Azure/sonic-snmpagent/pull/255.
If route change too fast between keys/hgetall, the original implementation will throw exception and lead to ERR in syslog.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

