### PR TITLE
[201811] Fix: not to use blocking get_all() after keys(), if routestr does not exist, skip

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -115,14 +115,15 @@ class NextHopUpdater(MIBUpdater):
             ipnstr = routestr[len("ROUTE_TABLE:"):]
             if ipnstr == "0.0.0.0/0":
                 ipn = ipaddress.ip_network(ipnstr)
-                ent = self.db_conn.get_all(mibs.APPL_DB, routestr, blocking=True)
-                nexthops = ent[b"nexthop"].decode()
-                for nh in nexthops.split(','):
-                    # TODO: if ipn contains IP range, create more sub_id here
-                    sub_id = ip2tuple_v4(ipn.network_address)
-                    self.route_list.append(sub_id)
-                    self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
-                    break # Just need the first nexthop
+                ent = self.db_conn.get_all(mibs.APPL_DB, routestr, blocking=False)
+                if ent:
+                    nexthops = ent[b"nexthop"].decode()
+                    for nh in nexthops.split(','):
+                        # TODO: if ipn contains IP range, create more sub_id here
+                        sub_id = ip2tuple_v4(ipn.network_address)
+                        self.route_list.append(sub_id)
+                        self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
+                        break # Just need the first nexthop
 
         self.route_list.sort()
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -67,7 +67,7 @@ class FdbUpdater(MIBUpdater):
                 mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': {}.".format(fdb_str, e))
                 break
 
-            ent = self.db_conn.get_all(mibs.ASIC_DB, s, blocking=True)
+            ent = self.db_conn.get_all(mibs.ASIC_DB, s, blocking=False)
             # Example output: oid:0x3a000000000608
             bridge_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
             if bridge_port_id not in self.if_bpid_map:

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -68,6 +68,9 @@ class FdbUpdater(MIBUpdater):
                 break
 
             ent = self.db_conn.get_all(mibs.ASIC_DB, s, blocking=False)
+            if not ent:
+                continue
+
             # Example output: oid:0x3a000000000608
             bridge_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
             if bridge_port_id not in self.if_bpid_map:


### PR DESCRIPTION
**- What I did**
Manual cherry-pick below commits and resolve conflicts.

1477c36 2022-05-04 | Fix: if routestr does not exist, skip (#257) [Qi Luo]
57f1af6 2022-05-02 | Fix: not to use blocking get_all() after keys() (#255) [Qi Luo]


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

