### PR TITLE
[201911] Fix snmp subagent errors in shutdown path

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -281,8 +281,7 @@ class MIBTable(dict):
             updater.run_event = event
             fut = asyncio.ensure_future(updater.start())
             fut.add_done_callback(MIBTable._done_background_task_callback)
-            task = event._loop.create_task(fut)
-            tasks.append(task)
+            tasks.append(fut)
         return asyncio.gather(*tasks, loop=event._loop)
 
     def _find_parent_prefix(self, item):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix an error raised in snmp container stop path. The issue is seen when SIGTERM is send to SNMP supervisord, and it attepmts to stop `snmp-subagent`.
There is a bug in subagent's shutdown path where below erros is seen upon receiving SIGTERM:
```
ERROR: Uncaught exception in sonic_ax_impl.main#012Traceback (most recent call last):#012  
File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/main.py", line 72, in main#012
    event_loop.run_until_complete(agent.run_in_event_loop())#012  
File "/usr/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete#012
    return future.result()#012  
File "/usr/local/lib/python3.6/dist-packages/ax_interface/agent.py", line 49, in run_in_event_loop#012
    await asyncio.wait_for(background_task, BACKGROUND_WAIT_TIMEOUT, loop=self.loop)#012  
File "/usr/lib/python3.6/asyncio/tasks.py", line 352, in wait_for#012
    return fut.result()#012AttributeError: '_asyncio.Task' object has no attribute 'send'
```

This issue turned out to be very costly in warmboot shutdown path. The SIGTERM sent to subagent never shutsdown the agent as it crashed. So supervisord waits for 10s before sending SIGKILL.

In some instances even kill signal to agent fails as the subagent has crashed, this makes dockerd to wait for 10 extra seconds to send SIGKILL to the container itself.

The 20s wait in the shutdown process is not only costly in terms of time spent, but it also makes dockerd to lock resources causing other `docker exec` commands to timeout.


**- How I did it**

Add future instance to tasks list, instead of another event loop task.

**- How to verify it**

Tested fix on physical testbed:

Without fix:
```
May 11 18:44:40.924339 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:40,923 INFO waiting for snmp-subagent to stop
May 11 18:44:40.924921 str-msn2700-04 INFO snmp#snmp-subagent [sonic_ax_impl] INFO: Recieved 'SIGTERM' signal, shutting down... <<------------ SIGTERM sent
May 11 18:44:40.925837 str-msn2700-04 INFO snmp#snmp-subagent [ax_interface] INFO: AgentX socket connection closed.
May 11 18:44:40.926798 str-msn2700-04 INFO snmp#snmp-subagent [ax_interface] INFO: Run disabled. Connection loop stopping...
May 11 18:44:40.930051 str-msn2700-04 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Uncaught exception in sonic_ax_impl.main#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/main.py", line 72, in main#012    event_loop.run_until_complete(agent.run_in_event_loop())#012  File "/usr/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete#012    return future.result()#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/agent.py", line 49, in run_in_event_loop#012    await asyncio.wait_for(background_task, BACKGROUND_WAIT_TIMEOUT, loop=self.loop)#012  File "/usr/lib/python3.6/asyncio/tasks.py", line 352, in wait_for#012    return fut.result()#012AttributeError: '_asyncio.Task' object has no attribute 'send'
May 11 18:44:42.924531 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:42,923 INFO waiting for snmp-subagent to stop
May 11 18:44:44.924686 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:44,924 INFO waiting for snmp-subagent to stop
May 11 18:44:46.925024 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:46,924 INFO waiting for snmp-subagent to stop
May 11 18:44:48.924974 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:48,924 INFO waiting for snmp-subagent to stop
May 11 18:44:50.925759 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:50,923 WARN killing 'snmp-subagent' (60) with SIGKILL <<------------ SIGKILL sent as failed to kill within 10s of SIGTERM
May 11 18:44:50.925946 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:50,924 INFO waiting for snmp-subagent to stop
May 11 18:44:50.934331 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:44:50,933 INFO stopped: snmp-subagent (terminated by SIGKILL)
```

With fix:
```
May 11 18:47:14.080425 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:47:14,079 INFO waiting for snmp-subagent to stop
May 11 18:47:14.080700 str-msn2700-04 INFO snmp#snmp-subagent [sonic_ax_impl] INFO: Recieved 'SIGTERM' signal, shutting down...
May 11 18:47:14.081162 str-msn2700-04 INFO snmp#snmp-subagent [ax_interface] INFO: AgentX socket connection closed.
May 11 18:47:14.081683 str-msn2700-04 INFO snmp#snmp-subagent [ax_interface] INFO: Run disabled. Connection loop stopping...
May 11 18:47:16.080595 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:47:16,080 INFO waiting for snmp-subagent to stop
May 11 18:47:18.080922 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:47:18,080 INFO waiting for snmp-subagent to stop
May 11 18:47:18.824394 str-msn2700-04 INFO snmp#snmp-subagent [sonic_ax_impl] INFO: Goodbye!
May 11 18:47:18.932172 str-msn2700-04 INFO snmp#supervisord 2022-05-11 18:47:18,931 INFO stopped: snmp-subagent (exit status 0)
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->