### PR TITLE
[snmp]: Remove redundant connections to dbs

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -232,9 +232,6 @@ def init_mgmt_interface_tables(db_conn):
     :return: tuple of mgmt name to oid map and mgmt name to alias map
     """
 
-    db_conn.connect(CONFIG_DB)
-    db_conn.connect(STATE_DB)
-
     mgmt_ports_keys = db_conn.keys(CONFIG_DB, mgmt_if_entry_table('*'))
 
     if not mgmt_ports_keys:
@@ -378,14 +375,11 @@ def init_sync_d_lag_tables(db_conn):
     # { lag_oid (SAI) -> lag_name (SONiC) }
     sai_lag_map = {}
 
-    db_conn.connect(APPL_DB)
-
     lag_entries = db_conn.keys(APPL_DB, "LAG_TABLE:*")
 
     if not lag_entries:
         return lag_name_if_name_map, if_name_lag_name_map, oid_lag_name_map, lag_sai_map, sai_lag_map
 
-    db_conn.connect(COUNTERS_DB)
     lag_sai_map = db_conn.get_all(COUNTERS_DB, "COUNTERS_LAG_NAME_MAP")
     for name, sai_id in lag_sai_map.items():
         sai_id_key = get_sai_id_key(db_conn.namespace, sai_id.lstrip("oid:0x"))
@@ -471,7 +465,6 @@ def get_device_metadata(db_conn):
     """
 
     DEVICE_METADATA = "DEVICE_METADATA|localhost"
-    db_conn.connect(db_conn.STATE_DB)
 
     device_metadata = db_conn.get_all(db_conn.STATE_DB, DEVICE_METADATA)
     return device_metadata
@@ -690,7 +683,6 @@ class Namespace:
     @staticmethod
     def dbs_get_vlan_id_from_bvid(dbs, bvid):
         for db_conn in Namespace.get_non_host_dbs(dbs):
-            db_conn.connect('ASIC_DB')
             vlan_obj = db_conn.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_VLAN:" + bvid)
             if vlan_obj is not None:
                 return port_util.get_vlan_id_from_bvid(db_conn, bvid)

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -122,8 +122,6 @@ class LLDPLocalSystemDataUpdater(MIBUpdater):
         """
         Subclass update data routine.
         """
-        # establish connection to application database.
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.loc_chassis_data = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE)
         if self.loc_chassis_data:
             self.loc_chassis_data['lldp_loc_sys_cap_supported'] = parse_sys_capability(self.loc_chassis_data.get('lldp_loc_sys_cap_supported', ''))
@@ -155,8 +153,6 @@ class LocPortUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = Namespace.init_namespace_dbs()
-        # establish connection to application database.
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.if_name_map = {}
         self.if_alias_map = {}
         self.if_id_map = {}
@@ -304,6 +300,7 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         super().__init__()
 
         self.db_conn = mibs.init_db()
+        self.db_conn.connect(mibs.APPL_DB)
         self.loc_chassis_data = {}
         self.man_addr_list = []
         self.mgmt_ip_str = None
@@ -316,7 +313,6 @@ class LLDPLocManAddrUpdater(MIBUpdater):
         self.mgmt_ip_str = None
 
         # establish connection to application database.
-        self.db_conn.connect(mibs.APPL_DB)
         mgmt_ip_bytes = self.db_conn.get(mibs.APPL_DB, mibs.LOC_CHASSIS_TABLE, 'lldp_loc_man_addr')
 
         if not mgmt_ip_bytes:
@@ -506,7 +502,6 @@ class LLDPRemManAddrUpdater(MIBUpdater):
 
         self.db_conn = Namespace.init_namespace_dbs()
         # establish connection to application database.
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.if_range = []
         self.oid_name_map = {}
         self.mgmt_oid_name_map = {}
@@ -581,9 +576,6 @@ class LLDPRemManAddrUpdater(MIBUpdater):
         self.mgmt_oid_name_map, _ = mibs.init_mgmt_interface_tables(self.db_conn[0])
 
         self.oid_name_map.update(self.mgmt_oid_name_map)
-
-        # establish connection to application database.
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
         self.if_range = []
         for if_oid, if_name in self.oid_name_map.items():

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -64,7 +64,6 @@ class ArpUpdater(MIBUpdater):
         self.neigh_key_list = {}
 
     def reinit_data(self):
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         self.neigh_key_list = Namespace.dbs_keys_namespace(self.db_conn, mibs.APPL_DB, "NEIGH_TABLE:*")
 
     def _update_from_arptable(self):
@@ -711,9 +710,9 @@ class sysNameUpdater(MIBUpdater):
         super().__init__()
         self.db_conn = mibs.init_db()
         self.hostname = socket.gethostname()
+        self.db_conn.connect(self.db_conn.CONFIG_DB)
 
     def reinit_data(self):
-        self.db_conn.connect(self.db_conn.CONFIG_DB)
         device_metadata = self.db_conn.get_all(self.db_conn.CONFIG_DB, "DEVICE_METADATA|localhost")
 
         if device_metadata and device_metadata.get('hostname'):

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -220,7 +220,6 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         super().__init__()
 
         self.statedb = Namespace.init_namespace_dbs()
-        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
 
         # List of available sub OIDs.
         self.physical_entities = []

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -356,7 +356,6 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         super().__init__()
 
         self.statedb = Namespace.init_namespace_dbs()
-        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
 
         # list of available sub OIDs
         self.sub_ids = []

--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -26,7 +26,6 @@ class BgpSessionUpdater(MIBUpdater):
         self.session_status_list = []
 
     def reinit_data(self):
-        Namespace.connect_all_dbs(self.db_conn, mibs.STATE_DB)
         self.neigh_state_map = Namespace.dbs_keys_namespace(self.db_conn, mibs.STATE_DB, "NEIGH_STATE_TABLE|*")
 
     def update_data(self):


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
init_namespace_dbs() function establishes connections to all required DBs in all namespaces.
There are various connections done in periodic functions like reinit_data() or update_data() which creates many connections and increases the number of open fds for sonic_ax_impl processes eventually leading to error logs like:
```
RR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.7/dist-packages/ax_interface/mib.py", line 37, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 38, in reinit_data#012    self.oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_interface_tables, self.db_conn)#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/__init__.py", line 669, in get_sync_d_from_all_namespace#012    ns_tuple = per_namespace_func(db_conn)#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/__init__.py", line 268, in init_sync_d_interface_tables#012    if_name_map_util, if_id_map_util = port_util.get_interface_oid_map(db_conn, blocking=False)#012  File "/usr/local/lib/python3.7/dist-packages/swsssdk/port_util.py", line 73, in get_interface_oid_map#012    db.connect('COUNTERS_DB')#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1690, in connect#012    return _swsscommon.SonicV2Connector_Native_connect(self, db_name, retry_on)#012RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address
```
**- How I did it**
Remove establishing connections in periodic functions when the connection is already established during init.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

