### PR TITLE
azure-pipelines: update to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
         set -ex
         sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
         sudo apt-get -y install libhiredis0.14
-        sudo dpkg -i ../target/debs/bookworm/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
+        sudo dpkg -i ../target/debs/bookworm/{libyang_3.*.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/bookworm/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/bookworm/sonic_py_common-1.0-py3-none-any.whl
         python3 setup.py bdist_wheel


### PR DESCRIPTION
#### Description

Port from libyang1 to libyang3. This depends on changes to sonic-buildimage.

Main Tracking ticket https://github.com/sonic-net/sonic-buildimage/issues/22385
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22385
