### PR TITLE
snmpagent: Implement an asyncio-based SNMP trap infrastructure supporting link up/down, PSU, and fan traps

### DIFF
--- a/src/ax_interface/agent.py
+++ b/src/ax_interface/agent.py
@@ -2,13 +2,14 @@ import asyncio
 
 from .mib import MIBTable, MIBMeta
 from .socket_io import SocketManager
+from .trap import TrapInfra
 
 # how long to wait before forcibly killing background task(s) during the shutdown procedure.
 BACKGROUND_WAIT_TIMEOUT = 10  # seconds
 
 
 class Agent:
-    def __init__(self, mib_cls, enable_dynamic_frequency, update_frequency, loop):
+    def __init__(self, mib_cls, enable_dynamic_frequency, update_frequency, loop, trap_handlers=None):
         if not type(mib_cls) is MIBMeta:
             raise ValueError("Expected a class with type: {}".format(MIBMeta))
 
@@ -19,8 +20,14 @@ class Agent:
         self.oid_updaters_enabled = asyncio.Event()
         self.stopped = asyncio.Event()
 
+        # Initialize our Trap infra
+        self.trap_infra = TrapInfra(loop, trap_handlers)
+
         # Initialize our MIB
-        self.mib_table = MIBTable(mib_cls, enable_dynamic_frequency, update_frequency)
+        if trap_handlers:
+            self.mib_table = MIBTable(mib_cls, enable_dynamic_frequency, update_frequency, self.trap_infra)
+        else:
+            self.mib_table = MIBTable(mib_cls, enable_dynamic_frequency, update_frequency)
 
         # containers
         self.socket_mgr = SocketManager(self.mib_table, self.run_enabled, self.loop)
@@ -54,6 +61,8 @@ class Agent:
     async def shutdown(self):
         # allow the agent to quit
         self.run_enabled.clear()
+        # shutdown trap infra
+        await self.trap_infra.shutdown()
         # close the socket
         self.socket_mgr.close()
         # wait for the agent to signal back

--- a/src/ax_interface/pdu_implementations.py
+++ b/src/ax_interface/pdu_implementations.py
@@ -362,12 +362,26 @@ class CleanupSetPDU(PDU):
         # header only.
 
 
-# class NotifyPDU(ContextOptionalPDU):
-#     """
-#         https://tools.ietf.org/html/rfc2741#section-6.2.10
-#         """
-#     header_type_ = PduTypes.NOTIFY
-# TODO: Impl
+class NotifyPDU(ContextOptionalPDU):
+    """
+        https://tools.ietf.org/html/rfc2741#section-6.2.10
+    """
+    header_type_ = PduTypes.NOTIFY
+
+    def __init__(self, header=None, context=None, payload=None, varBinds=[]):
+        super().__init__(header=header, context=context, payload=payload)
+
+        self.varBinds = varBinds
+        # Reducing the header length as per RFC 2741
+        # https://tools.ietf.org/html/rfc2741#section-6.1
+        payload_len = len(self.encode()) - constants.AGENTX_HEADER_LENGTH
+        self.header = self.header._replace(payload_length=payload_len)
+
+    def encode(self):
+        ret = super().encode()
+        for value in self.varBinds:
+            ret += value.to_bytes(self.header.endianness)
+        return ret
 
 
 

--- a/src/ax_interface/protocol.py
+++ b/src/ax_interface/protocol.py
@@ -4,6 +4,7 @@ from . import logger, constants, exceptions
 from .encodings import ObjectIdentifier
 from .pdu import PDUHeader, PDUStream
 from .pdu_implementations import RegisterPDU, ResponsePDU, OpenPDU
+from .trap import TrapInfra
 
 
 class AgentX(asyncio.Protocol):
@@ -49,6 +50,7 @@ class AgentX(asyncio.Protocol):
 
     def register_subtrees(self, pdu):
         self.session_id = pdu.header.session_id
+        TrapInfra.protocol_obj = self
         logger.info("AgentX session starting with ID: {}".format(self.session_id))
 
         for idx, subtree in enumerate(self.mib_table.prefixes):

--- a/src/ax_interface/trap.py
+++ b/src/ax_interface/trap.py
@@ -1,0 +1,383 @@
+import asyncio
+import re
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from . import logger, constants
+from .mib import ValueType
+from .encodings import ObjectIdentifier, ValueRepresentation
+from .pdu import PDUHeader
+from .pdu_implementations import NotifyPDU
+
+# Use redis-py asyncio API (redis>=4.2).
+import redis.asyncio as redis
+
+class TrapInfra:
+    """
+    Trap infrastructure core services.
+    All logic preserved from original implementation.
+    """
+
+    protocol_obj = None  # set by AgentX protocol
+
+    # Delay before a reader retries after losing its redis pubsub connection.
+    RECONNECT_BACKOFF_SECONDS = 5
+
+    def __init__(self, loop, trap_handlers):
+        logger.debug("Init begins for Trap infra")
+
+        self.loop = loop
+        self.redis_instances = {}
+        self.db_to_redis_dict = {}
+        self.dbKeyToHandler = {}
+        # precompiled patterns: list[(compiled_regex, [handlers], original_pattern)]
+        self._compiled_patterns = []
+        # reader tasks for graceful shutdown
+        self._reader_tasks = []
+        # Handlers perform blocking Redis reads (swsscommon). Run them off the
+        # event loop thread so a burst of keyspace notifications can't stall
+        # pubsub message delivery. Single worker preserves the original
+        # in-order, non-concurrent handler semantics.
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="trap-handler")
+
+        if trap_handlers is None:
+            return
+
+        self._init_trap_handlers(trap_handlers)
+
+        logger.debug("Init successful for Trap infra")
+
+    def _init_trap_handlers(self, trap_handlers):
+        trap_handlers_set = set(trap_handlers)
+
+        for handler_cls in trap_handlers_set:
+            handler = handler_cls()
+            for dbkey in handler.dbKeys:
+                if dbkey not in self.dbKeyToHandler:
+                    self.dbKeyToHandler[dbkey] = []
+                self.dbKeyToHandler[dbkey].append(handler)
+
+            handler.trap_init()
+
+    async def db_listener(self):
+        """
+        Coroutine which listens for DB notification events using redis.asyncio.
+        """
+        logger.debug("starting redis co routine")
+        logger.info("starting redis DB listener routine")
+
+        self._load_db_config()
+        # compile patterns once for fast matching and correct escaping
+        self._compile_patterns()
+
+        # Register keyspace patterns to redis (use original patterns)
+        for pattern in self.dbKeyToHandler.keys():
+            self._register_pattern(pattern)
+
+        # One self-healing reader task per redis instance
+        for instance in self.redis_instances:
+            redis_info = self.redis_instances[instance]
+            if redis_info["patternObjs"]:
+                task = asyncio.create_task(self._reader_loop(instance))
+                self._reader_tasks.append(task)
+
+    async def _reader_loop(self, instance):
+        """
+        Subscribe to this redis instance's keyspace patterns and process
+        notifications until cancelled.
+
+        Unlike a plain listen loop, any error (connection drop, protocol
+        hiccup, etc.) is caught and retried with a backoff instead of
+        letting the task die silently - a dead reader previously meant
+        permanent, unnoticed loss of all traps for that DB instance until
+        the whole process was restarted.
+        """
+        redis_info = self.redis_instances[instance]
+        address = f"redis://{redis_info['host']}:{redis_info['port']}"
+
+        while True:
+            pubsub = None
+            try:
+                redis_info["connection_obj"] = redis.from_url(address, decode_responses=False)
+                pubsub = redis_info["connection_obj"].pubsub(ignore_subscribe_messages=True)
+                redis_info["pubsub"] = pubsub
+
+                await pubsub.psubscribe(*redis_info["patternObjs"])
+                logger.debug("Listening for notifications on {}".format(instance))
+
+                async for message in pubsub.listen():
+                    if message['type'] in ('pmessage', 'message'):
+                        channel = message['channel']
+                        data = message['data']
+                        # The handlers do blocking Redis reads (swsscommon).
+                        # Run them off the event loop thread so they can't
+                        # stall delivery of the next pubsub message; the
+                        # actual trap PDU send still happens back here, on
+                        # the event loop thread, since it isn't thread-safe.
+                        results = await self.loop.run_in_executor(
+                            self._executor, self._collect_traps, channel, [data]
+                        )
+                        for result in results:
+                            self._send_trap(result)
+                            logger.debug("Trap dispatched successfully for {}".format(channel))
+            except asyncio.CancelledError:
+                # normal during shutdown
+                logger.debug("Trap redis reader cancelled for {}".format(instance))
+                raise
+            except Exception as e:
+                logger.error(
+                    "Reader loop for {} encountered an error, reconnecting in {}s: {}".format(
+                        instance, self.RECONNECT_BACKOFF_SECONDS, e
+                    ),
+                    exc_info=True
+                )
+            finally:
+                if pubsub is not None:
+                    try:
+                        await pubsub.close()
+                    except Exception:
+                        pass
+
+            await asyncio.sleep(self.RECONNECT_BACKOFF_SECONDS)
+
+    def _compile_patterns(self):
+        """
+        Compile redis keyspace patterns to safe, anchored regex.
+        Rule: '*' -> '.*'; other characters are escaped literally.
+        """
+        self._compiled_patterns.clear()
+        for pattern, handlers in self.dbKeyToHandler.items():
+            # escape everything then re-enable '*' as wildcard
+            escaped = re.escape(pattern)
+            # replace escaped '*' with '.*' for wildcard semantics
+            regex_str = '^' + escaped.replace(r'\*', '.*') + '$'
+            try:
+                cregex = re.compile(regex_str)
+            except re.error:
+                logger.error("Invalid trap pattern after compile: %s -> %s", pattern, regex_str)
+                continue
+            self._compiled_patterns.append((cregex, handlers, pattern))
+
+    def _load_db_config(self):
+        CONFIG_FILE = os.getenv(
+            'DB_CONFIG_FILE',
+            "/var/run/redis/sonic-db/database_config.json"
+        )
+
+        if not os.path.exists(CONFIG_FILE):
+            raise RuntimeError(
+                "[Trap:db_listener - DB config file not found " + str(CONFIG_FILE)
+            )
+
+        with open(CONFIG_FILE, "r") as config_file:
+            db_config_data = json.load(config_file)
+
+        if 'INSTANCES' not in db_config_data:
+            raise RuntimeError(
+                "[Trap:db_listener - No DB instances found in DB config file"
+            )
+
+        # Init redis instances
+        for instance in db_config_data['INSTANCES']:
+            entry = db_config_data['INSTANCES'][instance]
+            if instance not in self.redis_instances:
+                self.redis_instances[instance] = {
+                    "host": entry["hostname"],
+                    "port": entry["port"],
+                    "keyPatterns": [],
+                    "patternObjs": [],
+                    "pubsub": None,
+                    "connection_obj": None
+                }
+
+        # Map DB number to redis instance
+        for db in db_config_data['DATABASES']:
+            entry = db_config_data['DATABASES'][db]
+            db_id = int(entry["id"])
+
+            if db_id not in self.db_to_redis_dict:
+                instance_name = entry["instance"]
+                if instance_name not in self.redis_instances:
+                    raise RuntimeError(
+                        "[Trap:db_listener - No DB instance found for " +
+                        str(instance_name)
+                    )
+                self.db_to_redis_dict[db_id] = self.redis_instances[instance_name]
+
+    def _register_pattern(self, pattern):
+        match = re.match(r'__keyspace@(\d+)__:', pattern)
+        if not match:
+            raise RuntimeError(
+                "[Trap:db_listener - DB number cannot be determined for key " +
+                str(pattern)
+            )
+
+        db_num = int(match.group(1))
+        db_instance = self.db_to_redis_dict[db_num]
+
+        db_instance["patternObjs"].append(pattern)
+        db_instance["keyPatterns"].append(pattern)
+
+    def dispatch_trap(self, varBinds):
+        """
+        Prepare Notify PDU and send to master using AgentX protocol.
+        """
+        logger.debug("dispatch_trap invoked")
+
+        if TrapInfra.protocol_obj is None:
+            logger.warning("Protocol Object is None, cannot process traps")
+            return
+
+        notifyPDU = NotifyPDU(
+            header=PDUHeader(
+                1,
+                constants.PduTypes.NOTIFY,
+                PDUHeader.MASK_NEWORK_BYTE_ORDER,
+                0,
+                TrapInfra.protocol_obj.session_id,
+                0, 0, 0
+            ),
+            varBinds=varBinds
+        )
+
+        TrapInfra.protocol_obj.send_pdu(notifyPDU)
+        logger.debug("processed trap successfully")
+
+    def _collect_traps(self, channel, msg):
+        """
+        Invoke registered trap handlers for the given Redis notification and
+        return the list of trap dicts (if any) they produced.
+
+        This does the blocking work (handler.trap_process() performs
+        synchronous Redis reads via swsscommon) and is run on a worker
+        thread by _reader_loop - it must NOT touch the AgentX transport,
+        which is only safe to use from the event loop thread. Sending is
+        done by the caller via _send_trap() after this returns.
+        """
+        # Decode channel name, e.g., "__keyspace@6__:PSU_INFO|Psu1"
+        full_channel = channel.decode('utf-8') if isinstance(channel, bytes) else str(channel)
+        # msg[0] is the operation type, e.g., "hset" (not the key itself)
+        operation = msg[0].decode('utf-8') if isinstance(msg[0], bytes) else str(msg[0])
+
+        logger.debug("Redis Event: Channel={}, Operation={}".format(full_channel, operation))
+
+        # Find matching handlers (precompiled regexes)
+        handlers_to_call = []
+        for cregex, handlers, original in self._compiled_patterns:
+            if cregex.fullmatch(full_channel):
+                logger.debug("Channel %s matched pattern %s", full_channel, original)
+                handlers_to_call.extend(handlers)
+
+        if not handlers_to_call:
+            logger.debug("No handlers matched for {}".format(full_channel))
+            return []
+
+        # Invoke all matched handlers, collecting whatever traps they produce
+        results = []
+        for handler in handlers_to_call:
+            try:
+                # Pass full_channel to handler so it can determine the exact PSU/FAN
+                result = handler.trap_process(msg, full_channel)
+
+                if result is None:
+                    continue
+
+                assert isinstance(result, dict)
+                assert 'TrapOid' in result
+                assert 'varBinds' in result
+
+                results.append(result)
+            except Exception as e:
+                logger.error("Error executing handler {}: {}".format(handler, e), exc_info=True)
+
+        return results
+
+    def _send_trap(self, result):
+        varbinds = result['varBinds']
+        trap_oid = result['TrapOid']
+
+        assert isinstance(trap_oid, ObjectIdentifier)
+
+        varbinds_list = []
+
+        # Standard SNMP trap OID
+        snmp_trap_oid = ObjectIdentifier(
+            11, 0, 0, 0,
+            (1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0)
+        )
+
+        varbinds_list.append(
+            ValueRepresentation(
+                ValueType.OBJECT_IDENTIFIER,
+                0,
+                snmp_trap_oid,
+                trap_oid
+            )
+        )
+
+        if not varbinds:
+            raise RuntimeError("Return value must contain atleast one VarBind")
+
+        for vb in varbinds:
+            if not isinstance(vb, ValueRepresentation):
+                raise RuntimeError(
+                    "list entry is not of type ValueRepresentation"
+                )
+            varbinds_list.append(vb)
+
+        self.dispatch_trap(varbinds_list)
+
+    async def shutdown(self):
+        # stop readers first
+        for t in self._reader_tasks:
+            t.cancel()
+        if self._reader_tasks:
+            await asyncio.gather(*self._reader_tasks, return_exceptions=True)
+
+        for instance in self.redis_instances:
+            redis_info = self.redis_instances[instance]
+
+            if redis_info["keyPatterns"] and redis_info["pubsub"]:
+                try:
+                    await redis_info["pubsub"].punsubscribe(*redis_info["keyPatterns"])
+                except Exception as e:
+                    logger.debug("punsubscribe error on %s: %s", instance, e)
+
+            if redis_info["pubsub"]:
+                try:
+                    await redis_info["pubsub"].close()
+                except Exception:
+                    pass
+            if redis_info["connection_obj"]:
+                try:
+                    await redis_info["connection_obj"].close()
+                except Exception:
+                    pass
+
+        self._executor.shutdown(wait=False)
+
+
+class Trap:
+    """
+    Interface for developing Trap handlers.
+    """
+
+    def __init__(self, **kwargs):
+        self.run_event = asyncio.Event()
+        db_keys = kwargs.get("dbKeys")
+        if not isinstance(db_keys, list):
+            raise TypeError("Trap requires dbKeys=list of keyspace patterns")
+        self.dbKeys = db_keys
+
+    def trap_init(self):
+        """
+        Children may override this method.
+        """
+        logger.info("I am trap_init from infra")
+
+    def trap_process(self, dbMessage, changedKey):
+        """
+        Children may override this method.
+        """
+        logger.info("I am trap_process from infra")

--- a/src/sonic_ax_impl/mibs/ietf/link_up_down_trap.py
+++ b/src/sonic_ax_impl/mibs/ietf/link_up_down_trap.py
@@ -1,0 +1,230 @@
+import re
+
+from ax_interface.mib import ValueType
+from sonic_ax_impl import mibs
+from sonic_ax_impl.mibs import Namespace
+from ax_interface.trap import Trap
+from ax_interface.encodings import ObjectIdentifier, ValueRepresentation
+
+
+class linkUpDownTrap(Trap):
+    """
+    Link up/down SNMP trap handler.
+
+    Logic is fully equivalent to the original implementation,
+    including mgmt port behavior.
+    Only structure / readability optimized.
+    """
+
+    STATUS_MAP = {
+        "up": 1,
+        "down": 2
+    }
+
+    TRAP_OID_MAP = {
+        "up":   (1, 3, 6, 1, 6, 3, 1, 1, 5, 4),
+        "down": (1, 3, 6, 1, 6, 3, 1, 1, 5, 3)
+    }
+
+    IF_RULES = [
+        ("PORT_TABLE:Ethernet", lambda k: k[11:], "etherTable"),
+        ("LAG_TABLE:PortChannel", lambda k: k[10:], "portChannelTable"),
+        ("MGMT_PORT|", lambda k: k.split('|')[1], "mgmtDict"),
+        ("MGMT_PORT_TABLE|", lambda k: k.split('|')[1], "mgmtDict"),
+    ]
+
+    def __init__(self):
+        super().__init__(dbKeys=[
+            "__keyspace@0__:LAG_TABLE:PortChannel*",
+            "__keyspace@0__:PORT_TABLE:Ethernet*",
+            "__keyspace@6__:MGMT_PORT_TABLE|eth*",
+            "__keyspace@4__:MGMT_PORT|eth*"
+        ])
+
+        self.db_conn = Namespace.init_namespace_dbs()
+        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+        Namespace.connect_all_dbs(self.db_conn, mibs.CONFIG_DB)
+        Namespace.connect_all_dbs(self.db_conn, mibs.STATE_DB)
+
+        self.etherTable = {}
+        self.portChannelTable = {}
+        self.mgmtDict = {}
+
+    def trap_init(self):
+        self._init_ethernet_ports()
+        self._init_port_channels()
+        self._init_mgmt_ports()
+
+    def _init_ethernet_ports(self):
+        keys = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "PORT_TABLE:Ethernet*") or []
+
+        for key in keys:
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, key, blocking=True)
+            port_name = key.split("PORT_TABLE:")[-1]
+            self.etherTable[port_name] = {
+                'admin_status': entry.get('admin_status', 'down'),
+                'oper_status': entry.get('oper_status', 'down')
+            }
+
+    def _init_port_channels(self):
+        keys = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "LAG_TABLE:PortChannel*") or []
+
+        for key in keys:
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, key, blocking=True)
+            portchannel_name = key.split("LAG_TABLE:")[-1]
+            self.portChannelTable[portchannel_name] = {
+                'admin_status': entry.get('admin_status', 'down'),
+                'oper_status': entry.get('oper_status', 'down')
+            }
+
+    def _init_mgmt_ports(self):
+        # CONFIG DB: admin_status
+        config_keys = Namespace.dbs_keys(self.db_conn, mibs.CONFIG_DB, "MGMT_PORT|eth*") or []
+
+        for key in config_keys:
+            if_name = key.split('|')[1]
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.CONFIG_DB, key, blocking=True)
+            self.mgmtDict[if_name] = {
+                'admin_status': entry.get('admin_status', 'down'),
+                'oper_status': 'down'
+            }
+
+        # STATE DB: oper_status
+        state_keys = Namespace.dbs_keys(self.db_conn, mibs.STATE_DB, "MGMT_PORT_TABLE|eth*") or []
+
+        for key in state_keys:
+            if_name = key.split('|')[1]
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB, key, blocking=True)
+            if if_name not in self.mgmtDict:
+                self.mgmtDict[if_name] = {
+                    'admin_status': 'down',
+                    'oper_status': entry.get('oper_status', 'down')
+                }
+            else:
+                self.mgmtDict[if_name]['oper_status'] = entry.get('oper_status', 'down')
+
+    def trap_process(self, dbMessage, changedKey):
+        genTrap = False
+
+        db_num, actualKey = self._parse_changed_key(changedKey)
+        if not actualKey:
+            return None
+
+        admin_status, oper_status = self._get_status_from_db(db_num, actualKey)
+        if admin_status is None or oper_status is None:
+            return None
+
+        if_name, cache = self._match_interface(actualKey)
+
+        cache_key = if_name
+        if cache_key not in cache:
+            cache[cache_key] = {
+                'admin_status': admin_status,
+                'oper_status': oper_status
+            }
+            genTrap = True
+        else:
+            if (cache[cache_key]['admin_status'] != admin_status or
+                    cache[cache_key]['oper_status'] != oper_status):
+                cache[cache_key]['admin_status'] = admin_status
+                cache[cache_key]['oper_status'] = oper_status
+                genTrap = True
+
+        if not genTrap:
+            mibs.logger.debug("No change in DB entry, therefore Trap is not generated")
+            return None
+
+        return self._build_trap(if_name, admin_status, oper_status)
+
+    def _parse_changed_key(self, changedKey):
+        m = re.match(r'__keyspace@(\d+)__:(.*)', changedKey)
+        if not m:
+            return None, None
+        return m.group(1), m.group(2)
+
+    def _get_status_from_db(self, db_num, actualKey):
+        try:
+            if db_num == '6':  # STATE_DB (mgmt oper)
+                entry = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB, actualKey, blocking=False)
+                if not entry:
+                    return None, None
+                if_name = actualKey.split('|')[1]
+                oper_status = entry.get('oper_status', 'down')
+                admin_status = self.mgmtDict.get(if_name, {}).get('admin_status', 'down')
+
+            elif db_num == '4':  # CONFIG_DB (mgmt admin)
+                entry = Namespace.dbs_get_all(self.db_conn, mibs.CONFIG_DB, actualKey, blocking=False)
+                if not entry:
+                    return None, None
+                if_name = actualKey.split('|')[1]
+                admin_status = entry.get('admin_status', 'down')
+                oper_status = self.mgmtDict.get(if_name, {}).get('oper_status', 'down')
+
+            else:  # APPL_DB
+                entry = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, actualKey, blocking=False)
+                if not entry:
+                    return None, None
+                admin_status = entry.get('admin_status', 'down')
+                oper_status = entry.get('oper_status', 'down')
+
+            return admin_status, oper_status
+
+        except Exception as e:
+            mibs.logger.warning("{}, no Trap generated.".format(e))
+            return None, None
+
+    def _match_interface(self, actualKey):
+        for prefix, name_fn, cache_name in self.IF_RULES:
+            if actualKey.startswith(prefix):
+                return name_fn(actualKey), getattr(self, cache_name)
+        return None, None
+
+    def _build_trap(self, if_name, admin_status, oper_status):
+        if oper_status not in self.TRAP_OID_MAP:
+            mibs.logger.warning("Incorrect entry in DB for oper_status, No Trap generated")
+            return None
+
+        if_index = mibs.get_index_from_str(if_name)
+
+        varBinds = []
+
+        # ifIndex
+        varBinds.append(
+            ValueRepresentation(
+                ValueType.INTEGER, 0,
+                ObjectIdentifier(
+                    11, 0, 0, 0,
+                    (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, if_index)
+                ),
+                if_index
+            )
+        )
+
+        # adminStatus
+        varBinds.append(
+            ValueRepresentation(
+                ValueType.INTEGER, 0,
+                ObjectIdentifier(
+                    11, 0, 0, 0,
+                    (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, if_index)
+                ),
+                self.STATUS_MAP[admin_status]
+            )
+        )
+
+        # operStatus
+        varBinds.append(
+            ValueRepresentation(
+                ValueType.INTEGER, 0,
+                ObjectIdentifier(
+                    11, 0, 0, 0,
+                    (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, if_index)
+                ),
+                self.STATUS_MAP[oper_status]
+            )
+        )
+
+        return {
+            "TrapOid": ObjectIdentifier(10, 0, 0, 0, self.TRAP_OID_MAP[oper_status]),
+            "varBinds": varBinds
+        }

--- a/src/sonic_ax_impl/mibs/ietf/psu_fan_trap.py
+++ b/src/sonic_ax_impl/mibs/ietf/psu_fan_trap.py
@@ -1,0 +1,230 @@
+import re
+from ax_interface.mib import ValueType
+from sonic_ax_impl import mibs
+from sonic_ax_impl.mibs import Namespace
+from ax_interface.trap import Trap
+from ax_interface.encodings import ObjectIdentifier, ValueRepresentation
+
+
+class psuFanTrap(Trap):
+    # Cisco EnvMon fan status values
+    FAN_STATUS_MAP = {
+        "unknown": 1,
+        "up": 2,
+        "down": 3,
+        "warning": 4
+    }
+
+    # Cisco EnvMon PSU status values
+    PSU_STATUS_MAP = {
+        "offEnvOther": 1,
+        "on": 2,
+        "offAdmin": 3,
+        "offDenied": 4,
+        "offEnvPower": 5,
+        "offEnvTemp": 6,
+        "offEnvFan": 7,
+        "failed": 8,
+        "onButFanFail": 9,
+        "offCooling": 10,
+        "offConnectorRating": 11,
+        "onButInLinePowerFail": 12
+    }
+
+    def __init__(self):
+        # Subscribe to Redis keyspace notifications for FAN and PSU info
+        super().__init__(dbKeys=[
+            "__keyspace@6__:FAN_INFO|*",
+            "__keyspace@6__:PSU_INFO|*"
+        ])
+
+        self.db_conn = Namespace.init_namespace_dbs()
+        Namespace.connect_all_dbs(self.db_conn, mibs.STATE_DB)
+
+        # Cache ONLY the final mapped status value
+        # Key   -> Redis key (e.g. FAN_INFO|PSU1_FAN1)
+        # Value -> INTEGER value actually sent in SNMP trap
+        self.fanTable = {}
+        self.psuTable = {}
+
+    def trap_init(self):
+        """
+        Preload current device state at startup.
+
+        This prevents sending SNMP traps immediately after
+        snmp-subagent restart for already-existing conditions.
+        """
+        self._init_fan_table()
+        self._init_psu_table()
+
+    def _init_fan_table(self):
+        keys = Namespace.dbs_keys(self.db_conn, mibs.STATE_DB, "FAN_INFO|*") or []
+
+        for key in keys:
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB, key, blocking=True)
+            if not entry:
+                continue
+
+            # Store the computed fan status, not raw DB fields
+            self.fanTable[key] = self._calc_fan_status(entry)
+
+    def _init_psu_table(self):
+        keys = Namespace.dbs_keys(self.db_conn, mibs.STATE_DB, "PSU_INFO|*") or []
+
+        for key in keys:
+            entry = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB, key, blocking=True)
+            if not entry:
+                continue
+
+            # Store the computed PSU status, not raw DB fields
+            self.psuTable[key] = self._calc_psu_status(entry)
+
+    def _parse_fan_index(self, key_suffix):
+        """
+        Convert Redis key suffix into Cisco EnvMon fan index.
+
+        Examples:
+          PSU1_FAN1   -> 101
+          PSU2_FAN1   -> 201
+          FANTRAY2_1  -> 21
+        """
+        key_upper = key_suffix.upper()
+
+        # PSU fan
+        match = re.fullmatch(r"PSU(\d+)_FAN(\d+)", key_upper)
+        if match:
+            return int(match.group(1)) * 100 + int(match.group(2))
+
+        # Fantray fan
+        match = re.fullmatch(r"FANTRAY(\d+)_(\d+)", key_upper)
+        if match:
+            return int(match.group(1)) * 10 + int(match.group(2))
+
+        # Unknown format
+        return 0
+
+    def _calc_fan_status(self, entry):
+        """
+        Calculate final fan status according to Cisco EnvMon rules.
+
+        IMPORTANT:
+        This function defines the *semantic state* of a fan.
+        SNMP traps must be triggered ONLY when this value changes.
+        """
+        presence = entry.get("presence", "false").lower()
+        status = entry.get("status", "false").lower()
+        is_under_speed = entry.get("is_under_speed", "false").lower()
+        is_over_speed = entry.get("is_over_speed", "false").lower()
+
+        if presence != "true":
+            return self.FAN_STATUS_MAP["down"]
+
+        if status != "true":
+            return self.FAN_STATUS_MAP["down"]
+
+        if is_under_speed == "true" or is_over_speed == "true":
+            return self.FAN_STATUS_MAP["warning"]
+
+        return self.FAN_STATUS_MAP["up"]
+
+    def _calc_psu_status(self, entry):
+        """
+        Calculate final PSU status according to Cisco EnvMon rules.
+
+        IMPORTANT:
+        Many DB fields may change (voltage, temp, etc),
+        but SNMP trap should only be sent if the *mapped status*
+        actually changes.
+        """
+        if entry.get("presence", "false").lower() != "true":
+            return self.PSU_STATUS_MAP["offEnvOther"]
+
+        if entry.get("status", "false").lower() != "true":
+            return self.PSU_STATUS_MAP["failed"]
+
+        if entry.get("power_overload", "false").lower() == "true":
+            return self.PSU_STATUS_MAP["offEnvPower"]
+
+        try:
+            voltage = float(entry.get("voltage", 0))
+            vmin = float(entry.get("voltage_min_threshold", 0))
+            vmax = float(entry.get("voltage_max_threshold", 0))
+            if (vmin and voltage < vmin) or (vmax and voltage > vmax):
+                return self.PSU_STATUS_MAP["onButInLinePowerFail"]
+        except ValueError:
+            pass
+
+        try:
+            temp = float(entry.get("temp", 0))
+            temp_th = float(entry.get("temp_threshold", 0))
+            if temp_th and temp >= temp_th:
+                return self.PSU_STATUS_MAP["offEnvTemp"]
+        except ValueError:
+            pass
+
+        return self.PSU_STATUS_MAP["on"]
+
+    def trap_process(self, dbMessage, changedKey):
+        """
+        Process Redis keyspace notification and decide
+        whether an SNMP trap should be sent.
+        """
+        returnDict = {}
+        varBindsList = []
+
+        # Extract real Redis key from keyspace notification
+        actualKey = changedKey.split(":", 1)[1] if ":" in changedKey else changedKey
+
+        dbEntry = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB, actualKey, blocking=False)
+        if not dbEntry:
+            return None
+
+        # ---------------- FAN ----------------
+        if actualKey.startswith("FAN_INFO|"):
+            fan_status_value = self._calc_fan_status(dbEntry)
+
+            # CRITICAL:
+            # Do NOT send trap if final fan status has not changed.
+            # This avoids trap storms caused by harmless DB updates.
+            if self.fanTable.get(actualKey) == fan_status_value:
+                return None
+
+            # Update cached status AFTER change is confirmed
+            self.fanTable[actualKey] = fan_status_value
+
+            key_suffix = actualKey.split("|", 1)[1]
+            fan_index = self._parse_fan_index(key_suffix)
+
+            returnDict["TrapOid"] = ObjectIdentifier(14, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 4, 1, 1, 1))
+
+            fan_status_oid = ObjectIdentifier(15, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 4, 1, 1, 1, fan_index))
+
+            varBindsList.append(ValueRepresentation(ValueType.INTEGER, 0, fan_status_oid, fan_status_value))
+
+        # ---------------- PSU ----------------
+        elif actualKey.startswith("PSU_INFO|"):
+            psu_status_value = self._calc_psu_status(dbEntry)
+
+            # CRITICAL:
+            # Only trigger trap on *mapped PSU status* change,
+            # not on raw field updates (voltage/temp polling).
+            if self.psuTable.get(actualKey) == psu_status_value:
+                return None
+
+            self.psuTable[actualKey] = psu_status_value
+
+            returnDict["TrapOid"] = ObjectIdentifier(14, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2))
+
+            key_suffix = actualKey.split("|", 1)[1]
+            psu_match = re.search(r"PSU\s*(\d+)", key_suffix, re.IGNORECASE)
+            psu_index = int(psu_match.group(1)) if psu_match else 0
+
+            psu_status_oid = ObjectIdentifier(15, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2, psu_index))
+
+            varBindsList.append(ValueRepresentation(ValueType.INTEGER, 0, psu_status_oid, psu_status_value))
+
+        if varBindsList:
+            returnDict["varBinds"] = varBindsList
+            return returnDict
+
+        return None

--- a/tests/test_link_up_down_trap.py
+++ b/tests/test_link_up_down_trap.py
@@ -1,0 +1,294 @@
+import os
+import sys
+from unittest import TestCase
+from unittest import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl import mibs
+from sonic_ax_impl.mibs import Namespace
+from sonic_ax_impl.mibs.ietf.link_up_down_trap import linkUpDownTrap
+
+
+def make_trap():
+    """Construct a linkUpDownTrap with the real DB layer stubbed out."""
+    with mock.patch.object(Namespace, 'init_namespace_dbs', return_value=["db"]), \
+         mock.patch.object(Namespace, 'connect_all_dbs'):
+        return linkUpDownTrap()
+
+
+class TestParseChangedKey(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_extracts_db_number_and_key(self):
+        db_num, key = self.trap._parse_changed_key("__keyspace@0__:PORT_TABLE:Ethernet1")
+        self.assertEqual(db_num, "0")
+        self.assertEqual(key, "PORT_TABLE:Ethernet1")
+
+    def test_malformed_key_returns_none_none(self):
+        db_num, key = self.trap._parse_changed_key("not-a-keyspace-notification")
+        self.assertIsNone(db_num)
+        self.assertIsNone(key)
+
+
+class TestMatchInterface(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_ethernet_port(self):
+        if_name, cache = self.trap._match_interface("PORT_TABLE:Ethernet1")
+        self.assertEqual(if_name, "Ethernet1")
+        self.assertIs(cache, self.trap.etherTable)
+
+    def test_port_channel(self):
+        if_name, cache = self.trap._match_interface("LAG_TABLE:PortChannel1")
+        self.assertEqual(if_name, "PortChannel1")
+        self.assertIs(cache, self.trap.portChannelTable)
+
+    def test_mgmt_port_config(self):
+        if_name, cache = self.trap._match_interface("MGMT_PORT|eth0")
+        self.assertEqual(if_name, "eth0")
+        self.assertIs(cache, self.trap.mgmtDict)
+
+    def test_mgmt_port_state(self):
+        if_name, cache = self.trap._match_interface("MGMT_PORT_TABLE|eth0")
+        self.assertEqual(if_name, "eth0")
+        self.assertIs(cache, self.trap.mgmtDict)
+
+    def test_unrecognized_key_returns_none_none(self):
+        if_name, cache = self.trap._match_interface("SOME_OTHER_TABLE:foo")
+        self.assertIsNone(if_name)
+        self.assertIsNone(cache)
+
+
+class TestGetStatusFromDb(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_appl_db_reads_both_statuses_directly(self):
+        entry = {"admin_status": "up", "oper_status": "down"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            admin, oper = self.trap._get_status_from_db("0", "PORT_TABLE:Ethernet1")
+        self.assertEqual((admin, oper), ("up", "down"))
+
+    def test_appl_db_missing_entry_returns_none_none(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            admin, oper = self.trap._get_status_from_db("0", "PORT_TABLE:Ethernet1")
+        self.assertEqual((admin, oper), (None, None))
+
+    def test_state_db_mgmt_oper_merges_with_cached_admin(self):
+        # db_num '6' == STATE_DB: only oper_status comes from the DB entry;
+        # admin_status is whatever is already cached for that interface.
+        self.trap.mgmtDict["eth0"] = {"admin_status": "up", "oper_status": "down"}
+        entry = {"oper_status": "up"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            admin, oper = self.trap._get_status_from_db("6", "MGMT_PORT_TABLE|eth0")
+        self.assertEqual((admin, oper), ("up", "up"))
+
+    def test_config_db_mgmt_admin_merges_with_cached_oper(self):
+        # db_num '4' == CONFIG_DB: only admin_status comes from the DB entry;
+        # oper_status is whatever is already cached for that interface.
+        self.trap.mgmtDict["eth0"] = {"admin_status": "down", "oper_status": "up"}
+        entry = {"admin_status": "up"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            admin, oper = self.trap._get_status_from_db("4", "MGMT_PORT|eth0")
+        self.assertEqual((admin, oper), ("up", "up"))
+
+    def test_state_db_mgmt_oper_defaults_when_uncached(self):
+        entry = {"oper_status": "down"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            admin, oper = self.trap._get_status_from_db("6", "MGMT_PORT_TABLE|eth0")
+        self.assertEqual((admin, oper), ("down", "down"))
+
+    def test_exception_from_db_layer_is_swallowed(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', side_effect=RuntimeError("boom")):
+            admin, oper = self.trap._get_status_from_db("0", "PORT_TABLE:Ethernet1")
+        self.assertEqual((admin, oper), (None, None))
+
+    def test_state_db_missing_entry_returns_none_none(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            admin, oper = self.trap._get_status_from_db("6", "MGMT_PORT_TABLE|eth0")
+        self.assertEqual((admin, oper), (None, None))
+
+    def test_config_db_missing_entry_returns_none_none(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            admin, oper = self.trap._get_status_from_db("4", "MGMT_PORT|eth0")
+        self.assertEqual((admin, oper), (None, None))
+
+
+class TestBuildTrap(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_unknown_oper_status_produces_no_trap(self):
+        result = self.trap._build_trap("Ethernet1", "up", "flapping")
+        self.assertIsNone(result)
+
+    def test_valid_status_produces_trap_with_correct_ifindex_and_oid(self):
+        result = self.trap._build_trap("Ethernet1", "up", "down")
+
+        self.assertEqual(result["TrapOid"].subids, (1, 3, 6, 1, 6, 3, 1, 1, 5, 3))
+        if_index_vb, admin_vb, oper_vb = result["varBinds"]
+        self.assertEqual(if_index_vb.name.subids, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 2))
+        self.assertEqual(if_index_vb.data, 2)
+        self.assertEqual(admin_vb.name.subids, (1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 2))
+        self.assertEqual(admin_vb.data, self.trap.STATUS_MAP["up"])
+        self.assertEqual(oper_vb.name.subids, (1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 2))
+        self.assertEqual(oper_vb.data, self.trap.STATUS_MAP["down"])
+
+    def test_linkup_uses_linkup_trap_oid(self):
+        result = self.trap._build_trap("Ethernet1", "up", "up")
+        self.assertEqual(result["TrapOid"].subids, (1, 3, 6, 1, 6, 3, 1, 1, 5, 4))
+
+
+class TestTrapProcess(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_first_observed_state_generates_trap(self):
+        entry = {"admin_status": "up", "oper_status": "down"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process([], "__keyspace@0__:PORT_TABLE:Ethernet1")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(self.trap.etherTable["Ethernet1"], {"admin_status": "up", "oper_status": "down"})
+
+    def test_unchanged_state_produces_no_trap(self):
+        self.trap.etherTable["Ethernet1"] = {"admin_status": "up", "oper_status": "down"}
+        entry = {"admin_status": "up", "oper_status": "down"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process([], "__keyspace@0__:PORT_TABLE:Ethernet1")
+        self.assertIsNone(result)
+
+    def test_oper_status_change_generates_trap_and_updates_cache(self):
+        self.trap.etherTable["Ethernet1"] = {"admin_status": "up", "oper_status": "down"}
+        entry = {"admin_status": "up", "oper_status": "up"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process([], "__keyspace@0__:PORT_TABLE:Ethernet1")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["TrapOid"].subids, (1, 3, 6, 1, 6, 3, 1, 1, 5, 4))  # linkUp
+        self.assertEqual(self.trap.etherTable["Ethernet1"]["oper_status"], "up")
+
+    def test_malformed_key_produces_no_trap(self):
+        result = self.trap.trap_process([], "not-a-keyspace-notification")
+        self.assertIsNone(result)
+
+    def test_missing_db_entry_produces_no_trap(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            result = self.trap.trap_process([], "__keyspace@0__:PORT_TABLE:Ethernet1")
+        self.assertIsNone(result)
+
+    def test_portchannel_state_change_generates_trap(self):
+        entry = {"admin_status": "up", "oper_status": "up"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process([], "__keyspace@0__:LAG_TABLE:PortChannel1")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(self.trap.portChannelTable["PortChannel1"]["oper_status"], "up")
+
+    def test_mgmt_port_admin_then_oper_change_both_trigger_and_merge(self):
+        # CONFIG_DB (admin) notification arrives first.
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value={"admin_status": "up"}):
+            result1 = self.trap.trap_process([], "__keyspace@4__:MGMT_PORT|eth0")
+        self.assertIsNotNone(result1)
+        self.assertEqual(self.trap.mgmtDict["eth0"], {"admin_status": "up", "oper_status": "down"})
+
+        # STATE_DB (oper) notification arrives next; admin_status must be preserved.
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value={"oper_status": "up"}):
+            result2 = self.trap.trap_process([], "__keyspace@6__:MGMT_PORT_TABLE|eth0")
+        self.assertIsNotNone(result2)
+        self.assertEqual(self.trap.mgmtDict["eth0"], {"admin_status": "up", "oper_status": "up"})
+        # The second trap must reflect the merged state, not just "up"/None.
+        oper_vb = result2["varBinds"][2]
+        self.assertEqual(oper_vb.data, self.trap.STATUS_MAP["up"])
+
+
+class TestInitTables(TestCase):
+    def test_init_ethernet_ports_populates_ether_table(self):
+        trap = make_trap()
+
+        def fake_dbs_keys(dbs, db_name, pattern):
+            return ["PORT_TABLE:Ethernet1"] if pattern == "PORT_TABLE:Ethernet*" else []
+
+        def fake_dbs_get_all(dbs, db_name, key, **kwargs):
+            return {"admin_status": "up", "oper_status": "down"}
+
+        with mock.patch.object(Namespace, 'dbs_keys', side_effect=fake_dbs_keys), \
+             mock.patch.object(Namespace, 'dbs_get_all', side_effect=fake_dbs_get_all):
+            trap._init_ethernet_ports()
+
+        self.assertEqual(
+            trap.etherTable["Ethernet1"], {"admin_status": "up", "oper_status": "down"}
+        )
+
+    def test_init_port_channels_populates_portchannel_table(self):
+        trap = make_trap()
+
+        def fake_dbs_keys(dbs, db_name, pattern):
+            return ["LAG_TABLE:PortChannel1"] if pattern == "LAG_TABLE:PortChannel*" else []
+
+        def fake_dbs_get_all(dbs, db_name, key, **kwargs):
+            return {"admin_status": "down", "oper_status": "down"}
+
+        with mock.patch.object(Namespace, 'dbs_keys', side_effect=fake_dbs_keys), \
+             mock.patch.object(Namespace, 'dbs_get_all', side_effect=fake_dbs_get_all):
+            trap._init_port_channels()
+
+        self.assertEqual(
+            trap.portChannelTable["PortChannel1"], {"admin_status": "down", "oper_status": "down"}
+        )
+
+    def test_init_mgmt_ports_state_only_interface_defaults_admin_down(self):
+        # An interface present in STATE_DB (oper) but absent from CONFIG_DB
+        # (admin) must still be recorded, with admin_status defaulted.
+        trap = make_trap()
+
+        def fake_dbs_keys(dbs, db_name, pattern):
+            return {
+                "MGMT_PORT|eth*": [],
+                "MGMT_PORT_TABLE|eth*": ["MGMT_PORT_TABLE|eth1"],
+            }.get(pattern, [])
+
+        def fake_dbs_get_all(dbs, db_name, key, **kwargs):
+            return {"MGMT_PORT_TABLE|eth1": {"oper_status": "up"}}.get(key, {})
+
+        with mock.patch.object(Namespace, 'dbs_keys', side_effect=fake_dbs_keys), \
+             mock.patch.object(Namespace, 'dbs_get_all', side_effect=fake_dbs_get_all):
+            trap._init_mgmt_ports()
+
+        self.assertEqual(trap.mgmtDict["eth1"], {"admin_status": "down", "oper_status": "up"})
+
+    def test_trap_init_calls_all_three_initializers(self):
+        trap = make_trap()
+        with mock.patch.object(trap, '_init_ethernet_ports') as mock_eth, \
+             mock.patch.object(trap, '_init_port_channels') as mock_lag, \
+             mock.patch.object(trap, '_init_mgmt_ports') as mock_mgmt:
+            trap.trap_init()
+
+        mock_eth.assert_called_once()
+        mock_lag.assert_called_once()
+        mock_mgmt.assert_called_once()
+
+    def test_init_mgmt_ports_merges_config_and_state(self):
+        trap = make_trap()
+
+        def fake_dbs_keys(dbs, db_name, pattern):
+            return {
+                "MGMT_PORT|eth*": ["MGMT_PORT|eth0"],
+                "MGMT_PORT_TABLE|eth*": ["MGMT_PORT_TABLE|eth0"],
+            }.get(pattern, [])
+
+        def fake_dbs_get_all(dbs, db_name, key, **kwargs):
+            return {
+                "MGMT_PORT|eth0": {"admin_status": "up"},
+                "MGMT_PORT_TABLE|eth0": {"oper_status": "up"},
+            }.get(key, {})
+
+        with mock.patch.object(Namespace, 'dbs_keys', side_effect=fake_dbs_keys), \
+             mock.patch.object(Namespace, 'dbs_get_all', side_effect=fake_dbs_get_all):
+            trap._init_mgmt_ports()
+
+        self.assertEqual(trap.mgmtDict["eth0"], {"admin_status": "up", "oper_status": "up"})

--- a/tests/test_psu_fan_trap.py
+++ b/tests/test_psu_fan_trap.py
@@ -1,0 +1,232 @@
+import os
+import sys
+from unittest import TestCase
+from unittest import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl.mibs.ietf.psu_fan_trap import psuFanTrap
+from sonic_ax_impl.mibs import Namespace
+
+
+def make_trap():
+    """Construct a psuFanTrap with the real DB layer stubbed out."""
+    with mock.patch.object(Namespace, 'init_namespace_dbs', return_value=["db"]), \
+         mock.patch.object(Namespace, 'connect_all_dbs'):
+        return psuFanTrap()
+
+
+class TestParseFanIndex(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_psu_internal_fan_index(self):
+        self.assertEqual(self.trap._parse_fan_index("PSU1_FAN1"), 101)
+        self.assertEqual(self.trap._parse_fan_index("PSU2_FAN1"), 201)
+
+    def test_fantray_index(self):
+        self.assertEqual(self.trap._parse_fan_index("FANTRAY2_1"), 21)
+        self.assertEqual(self.trap._parse_fan_index("FANTRAY1_2"), 12)
+
+    def test_is_case_insensitive(self):
+        self.assertEqual(self.trap._parse_fan_index("psu1_fan1"), 101)
+
+    def test_unknown_format_returns_zero(self):
+        self.assertEqual(self.trap._parse_fan_index("weirdname"), 0)
+
+
+class TestCalcFanStatus(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_absent_is_down(self):
+        entry = {"presence": "false", "status": "true"}
+        self.assertEqual(self.trap._calc_fan_status(entry), self.trap.FAN_STATUS_MAP["down"])
+
+    def test_bad_status_is_down(self):
+        entry = {"presence": "true", "status": "false"}
+        self.assertEqual(self.trap._calc_fan_status(entry), self.trap.FAN_STATUS_MAP["down"])
+
+    def test_under_speed_is_warning(self):
+        entry = {"presence": "true", "status": "true", "is_under_speed": "true"}
+        self.assertEqual(self.trap._calc_fan_status(entry), self.trap.FAN_STATUS_MAP["warning"])
+
+    def test_over_speed_is_warning(self):
+        entry = {"presence": "true", "status": "true", "is_over_speed": "true"}
+        self.assertEqual(self.trap._calc_fan_status(entry), self.trap.FAN_STATUS_MAP["warning"])
+
+    def test_normal_is_up(self):
+        entry = {
+            "presence": "true", "status": "true",
+            "is_under_speed": "false", "is_over_speed": "false",
+        }
+        self.assertEqual(self.trap._calc_fan_status(entry), self.trap.FAN_STATUS_MAP["up"])
+
+    def test_missing_fields_default_to_down_not_up(self):
+        # An empty/missing entry (e.g. key just deleted) must resolve to
+        # "down" via the field defaults, never silently read as "up".
+        self.assertEqual(self.trap._calc_fan_status({}), self.trap.FAN_STATUS_MAP["down"])
+
+
+class TestCalcPsuStatus(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_absent_is_offEnvOther(self):
+        entry = {"presence": "false"}
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["offEnvOther"])
+
+    def test_present_but_status_false_is_failed(self):
+        # Hardware-confirmed removal signature on this platform: `presence`
+        # stays "true" on physical removal, only `status` flips to false.
+        entry = {"presence": "true", "status": "false"}
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["failed"])
+
+    def test_power_overload_takes_priority_over_voltage_and_temp(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "true",
+            "voltage": "20", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["offEnvPower"])
+
+    def test_voltage_below_min_threshold_is_onButInLinePowerFail(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "9", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["onButInLinePowerFail"])
+
+    def test_voltage_above_max_threshold_is_onButInLinePowerFail(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "20", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["onButInLinePowerFail"])
+
+    def test_temp_at_or_above_threshold_is_offEnvTemp(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "12", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+            "temp": "60", "temp_threshold": "60",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["offEnvTemp"])
+
+    def test_normal_is_on(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "12.2", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+            "temp": "25", "temp_threshold": "60",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["on"])
+
+    def test_non_numeric_voltage_is_tolerated_not_raised(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "not-a-number",
+            "temp": "25", "temp_threshold": "60",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["on"])
+
+    def test_non_numeric_temp_is_tolerated_not_raised(self):
+        entry = {
+            "presence": "true", "status": "true", "power_overload": "false",
+            "voltage": "12", "voltage_min_threshold": "11", "voltage_max_threshold": "14",
+            "temp": "not-a-number", "temp_threshold": "60",
+        }
+        self.assertEqual(self.trap._calc_psu_status(entry), self.trap.PSU_STATUS_MAP["on"])
+
+
+class TestTrapInit(TestCase):
+    def test_preloads_fan_and_psu_tables(self):
+        trap = make_trap()
+
+        def fake_dbs_keys(dbs, db_name, pattern):
+            return {
+                "FAN_INFO|*": ["FAN_INFO|PSU1_FAN1"],
+                "PSU_INFO|*": ["PSU_INFO|Psu1"],
+            }.get(pattern, [])
+
+        def fake_dbs_get_all(dbs, db_name, key, **kwargs):
+            return {
+                "FAN_INFO|PSU1_FAN1": {"presence": "true", "status": "true"},
+                "PSU_INFO|Psu1": {"presence": "true", "status": "true"},
+            }.get(key, {})
+
+        with mock.patch.object(Namespace, 'dbs_keys', side_effect=fake_dbs_keys), \
+             mock.patch.object(Namespace, 'dbs_get_all', side_effect=fake_dbs_get_all):
+            trap.trap_init()
+
+        self.assertEqual(trap.fanTable["FAN_INFO|PSU1_FAN1"], trap.FAN_STATUS_MAP["up"])
+        self.assertEqual(trap.psuTable["PSU_INFO|Psu1"], trap.PSU_STATUS_MAP["on"])
+
+    def test_empty_db_entry_is_skipped_not_cached(self):
+        trap = make_trap()
+        with mock.patch.object(Namespace, 'dbs_keys', return_value=["FAN_INFO|Ghost"]), \
+             mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            trap.trap_init()
+        self.assertNotIn("FAN_INFO|Ghost", trap.fanTable)
+
+
+class TestTrapProcess(TestCase):
+    def setUp(self):
+        self.trap = make_trap()
+
+    def test_missing_db_entry_produces_no_trap(self):
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=None):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:PSU_INFO|Psu2")
+        self.assertIsNone(result)
+
+    def test_first_observed_fan_status_generates_a_trap(self):
+        entry = {"presence": "true", "status": "true"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:FAN_INFO|PSU2_FAN1")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["TrapOid"].subids, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 4, 1, 1, 1))
+        varbind = result["varBinds"][0]
+        self.assertEqual(varbind.name.subids, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 4, 1, 1, 1, 201))
+        self.assertEqual(varbind.data, self.trap.FAN_STATUS_MAP["up"])
+        self.assertEqual(self.trap.fanTable["FAN_INFO|PSU2_FAN1"], self.trap.FAN_STATUS_MAP["up"])
+
+    def test_unchanged_fan_status_produces_no_trap(self):
+        self.trap.fanTable["FAN_INFO|PSU2_FAN1"] = self.trap.FAN_STATUS_MAP["up"]
+        entry = {"presence": "true", "status": "true"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:FAN_INFO|PSU2_FAN1")
+        self.assertIsNone(result)
+
+    def test_fan_status_change_reports_fantray_index(self):
+        self.trap.fanTable["FAN_INFO|FANTRAY1_1"] = self.trap.FAN_STATUS_MAP["up"]
+        entry = {"presence": "false"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:FAN_INFO|FANTRAY1_1")
+
+        varbind = result["varBinds"][0]
+        self.assertEqual(varbind.name.subids[-1], 11)
+        self.assertEqual(varbind.data, self.trap.FAN_STATUS_MAP["down"])
+
+    def test_psu_status_change_generates_trap_with_correct_index(self):
+        entry = {"presence": "true", "status": "false"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:PSU_INFO|Psu2")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["TrapOid"].subids, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2))
+        varbind = result["varBinds"][0]
+        self.assertEqual(varbind.name.subids, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2, 2))
+        self.assertEqual(varbind.data, self.trap.PSU_STATUS_MAP["failed"])
+        self.assertEqual(self.trap.psuTable["PSU_INFO|Psu2"], self.trap.PSU_STATUS_MAP["failed"])
+
+    def test_unchanged_psu_status_produces_no_trap(self):
+        self.trap.psuTable["PSU_INFO|Psu2"] = self.trap.PSU_STATUS_MAP["on"]
+        entry = {"presence": "true", "status": "true", "power_overload": "false"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:PSU_INFO|Psu2")
+        self.assertIsNone(result)
+
+    def test_unrelated_key_produces_no_trap(self):
+        entry = {"foo": "bar"}
+        with mock.patch.object(Namespace, 'dbs_get_all', return_value=entry):
+            result = self.trap.trap_process(["hset"], "__keyspace@6__:SOME_OTHER_TABLE|x")
+        self.assertIsNone(result)

--- a/tests/test_trap.py
+++ b/tests/test_trap.py
@@ -1,0 +1,633 @@
+import asyncio
+import json
+import os
+import re
+import sys
+import tempfile
+from unittest import TestCase
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from ax_interface import trap as trap_module
+from ax_interface.trap import Trap, TrapInfra
+from ax_interface.encodings import ObjectIdentifier, ValueRepresentation
+from ax_interface.mib import ValueType
+
+
+def make_trap_result(index=1, value=2):
+    """Build a minimal, valid handler result dict as returned by Trap.trap_process()."""
+    status_oid = ObjectIdentifier(15, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2, index))
+    varbind = ValueRepresentation(ValueType.INTEGER, 0, status_oid, value)
+    return {
+        "TrapOid": ObjectIdentifier(14, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 117, 1, 1, 2, 1, 2)),
+        "varBinds": [varbind],
+    }
+
+
+class TestCollectTraps(TestCase):
+    """
+    _collect_traps() is the blocking-safe handler dispatcher that
+    _reader_loop() now runs on a worker thread via run_in_executor(). It must
+    never touch the AgentX transport and must isolate individual handler
+    failures instead of letting one bad handler take down the others.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def _register(self, pattern, handlers):
+        self.infra.dbKeyToHandler = {pattern: handlers}
+        self.infra._compile_patterns()
+
+    def test_no_matching_handlers_returns_empty_list(self):
+        self._register("__keyspace@6__:PSU_INFO|*", [MagicMock()])
+        result = self.infra._collect_traps(
+            b"__keyspace@6__:FAN_INFO|Fantray1_1", [b"hset"]
+        )
+        self.assertEqual(result, [])
+
+    def test_handler_returning_none_produces_no_trap(self):
+        handler = MagicMock()
+        handler.trap_process.return_value = None
+        self._register("__keyspace@6__:PSU_INFO|*", [handler])
+
+        result = self.infra._collect_traps(b"__keyspace@6__:PSU_INFO|Psu2", [b"hset"])
+
+        self.assertEqual(result, [])
+        handler.trap_process.assert_called_once()
+
+    def test_handler_result_is_collected(self):
+        handler = MagicMock()
+        expected = make_trap_result()
+        handler.trap_process.return_value = expected
+        self._register("__keyspace@6__:PSU_INFO|*", [handler])
+
+        result = self.infra._collect_traps(b"__keyspace@6__:PSU_INFO|Psu2", [b"hset"])
+
+        self.assertEqual(result, [expected])
+
+    def test_one_handler_raising_does_not_block_others(self):
+        bad_handler = MagicMock()
+        bad_handler.trap_process.side_effect = RuntimeError("boom")
+        good_handler = MagicMock()
+        good_handler.trap_process.return_value = make_trap_result(index=2)
+        self._register("__keyspace@6__:PSU_INFO|*", [bad_handler, good_handler])
+
+        result = self.infra._collect_traps(b"__keyspace@6__:PSU_INFO|Psu2", [b"hset"])
+
+        self.assertEqual(len(result), 1)
+        good_handler.trap_process.assert_called_once()
+
+    def test_malformed_handler_result_is_rejected_not_raised(self):
+        handler = MagicMock()
+        handler.trap_process.return_value = {"TrapOid": None}  # missing varBinds
+        self._register("__keyspace@6__:PSU_INFO|*", [handler])
+
+        # Should be swallowed by the per-handler try/except, not propagate.
+        result = self.infra._collect_traps(b"__keyspace@6__:PSU_INFO|Psu2", [b"hset"])
+        self.assertEqual(result, [])
+
+
+class TestSendAndDispatch(TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+
+    def tearDown(self):
+        self.loop.close()
+        TrapInfra.protocol_obj = None
+
+    def test_send_trap_prepends_standard_trap_oid_varbind(self):
+        result = make_trap_result()
+        with patch.object(self.infra, 'dispatch_trap') as mock_dispatch:
+            self.infra._send_trap(result)
+
+        mock_dispatch.assert_called_once()
+        varbinds_list = mock_dispatch.call_args[0][0]
+        self.assertEqual(len(varbinds_list), 2)
+        self.assertEqual(varbinds_list[0].name.subids, (1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0))
+        self.assertEqual(varbinds_list[1], result["varBinds"][0])
+
+    def test_send_trap_raises_on_empty_varbinds(self):
+        result = {"TrapOid": ObjectIdentifier(10, 0, 0, 0, (1, 3, 6, 1)), "varBinds": []}
+        with self.assertRaises(RuntimeError):
+            self.infra._send_trap(result)
+
+    def test_send_trap_raises_on_wrong_varbind_type(self):
+        result = {"TrapOid": ObjectIdentifier(10, 0, 0, 0, (1, 3, 6, 1)), "varBinds": ["not a varbind"]}
+        with self.assertRaises(RuntimeError):
+            self.infra._send_trap(result)
+
+    def test_dispatch_trap_is_noop_without_protocol_obj(self):
+        TrapInfra.protocol_obj = None
+        # Must not raise even though nothing is connected yet.
+        self.infra.dispatch_trap([])
+
+    def test_dispatch_trap_sends_pdu_when_protocol_available(self):
+        mock_protocol = MagicMock()
+        mock_protocol.session_id = 7
+        TrapInfra.protocol_obj = mock_protocol
+
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1))
+        varbind = ValueRepresentation(ValueType.INTEGER, 0, oid, 1)
+
+        self.infra.dispatch_trap([varbind])
+
+        mock_protocol.send_pdu.assert_called_once()
+
+
+class TestReaderLoopReconnect(TestCase):
+    """
+    Regression coverage for the self-healing reconnect behaviour: previously
+    any error inside the reader coroutine (e.g. a dropped redis connection)
+    caused it to exit silently and never resume, permanently losing all
+    traps for that DB instance. _reader_loop() must instead log, back off,
+    and retry.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+        self.infra.RECONNECT_BACKOFF_SECONDS = 0  # keep the test fast
+        pattern = "__keyspace@6__:PSU_INFO|*"
+        self.infra.redis_instances = {
+            "redis": {
+                "host": "127.0.0.1",
+                "port": 6379,
+                "keyPatterns": [pattern],
+                "patternObjs": [pattern],
+                "pubsub": None,
+                "connection_obj": None,
+            }
+        }
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_reconnects_after_subscribe_failure_instead_of_dying(self):
+        attempts = {"count": 0}
+
+        def fake_from_url(*args, **kwargs):
+            attempts["count"] += 1
+            pubsub = MagicMock()
+            pubsub.close = AsyncMock()
+            if attempts["count"] == 1:
+                # Simulate a broken connection on the first attempt.
+                pubsub.psubscribe = AsyncMock(side_effect=ConnectionError("boom"))
+            else:
+                # Second attempt succeeds and then idles until cancelled.
+                pubsub.psubscribe = AsyncMock()
+
+                async def hang_listen():
+                    await asyncio.Event().wait()
+                    yield  # pragma: no cover - never reached
+
+                pubsub.listen = hang_listen
+
+            conn = MagicMock()
+            conn.pubsub = MagicMock(return_value=pubsub)
+            return conn
+
+        with patch.object(trap_module.redis, 'from_url', side_effect=fake_from_url):
+            task = self.loop.create_task(self.infra._reader_loop("redis"))
+
+            async def drive():
+                await asyncio.sleep(0.05)
+                # Must have reconnected at least once after the first failure.
+                self.assertGreaterEqual(attempts["count"], 2)
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            self.loop.run_until_complete(drive())
+
+    def test_retries_even_if_pubsub_close_itself_fails_during_cleanup(self):
+        attempts = {"count": 0}
+
+        def fake_from_url(*args, **kwargs):
+            attempts["count"] += 1
+            pubsub = MagicMock()
+            # Cleanup itself is broken too - the loop must not let this
+            # secondary failure stop it from retrying.
+            pubsub.close = AsyncMock(side_effect=RuntimeError("close failed"))
+            pubsub.psubscribe = AsyncMock(side_effect=ConnectionError("boom"))
+            conn = MagicMock()
+            conn.pubsub = MagicMock(return_value=pubsub)
+            return conn
+
+        with patch.object(trap_module.redis, 'from_url', side_effect=fake_from_url):
+            task = self.loop.create_task(self.infra._reader_loop("redis"))
+
+            async def drive():
+                await asyncio.sleep(0.05)
+                self.assertGreaterEqual(attempts["count"], 2)
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            self.loop.run_until_complete(drive())
+
+    def test_cancellation_propagates_and_closes_pubsub(self):
+        pubsub = MagicMock()
+        pubsub.psubscribe = AsyncMock()
+        pubsub.close = AsyncMock()
+
+        async def hang_listen():
+            await asyncio.Event().wait()
+            yield  # pragma: no cover - never reached
+
+        pubsub.listen = hang_listen
+        conn = MagicMock()
+        conn.pubsub = MagicMock(return_value=pubsub)
+
+        with patch.object(trap_module.redis, 'from_url', return_value=conn):
+            task = self.loop.create_task(self.infra._reader_loop("redis"))
+
+            async def drive():
+                await asyncio.sleep(0.02)
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            self.loop.run_until_complete(drive())
+
+        pubsub.close.assert_called_once()
+
+
+class TestReaderLoopMessageFlow(TestCase):
+    """
+    End-to-end coverage of the new dispatch path: a real pubsub message is
+    handed to _collect_traps() via loop.run_in_executor() (a real
+    ThreadPoolExecutor, not mocked) and, once results come back on the event
+    loop thread, _send_trap()/dispatch_trap() actually fires.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+        self.infra.RECONNECT_BACKOFF_SECONDS = 0
+        pattern = "__keyspace@6__:PSU_INFO|*"
+        self.handler = MagicMock()
+        self.handler.trap_process.return_value = make_trap_result()
+        self.infra.dbKeyToHandler = {pattern: [self.handler]}
+        self.infra._compile_patterns()
+        self.infra.redis_instances = {
+            "redis": {
+                "host": "127.0.0.1",
+                "port": 6379,
+                "keyPatterns": [pattern],
+                "patternObjs": [pattern],
+                "pubsub": None,
+                "connection_obj": None,
+            }
+        }
+
+    def tearDown(self):
+        self.loop.close()
+        TrapInfra.protocol_obj = None
+
+    def test_message_is_processed_off_thread_and_trap_dispatched(self):
+        mock_protocol = MagicMock()
+        mock_protocol.session_id = 7
+        TrapInfra.protocol_obj = mock_protocol
+
+        pubsub = MagicMock()
+        pubsub.psubscribe = AsyncMock()
+        pubsub.close = AsyncMock()
+
+        async def one_message_then_hang():
+            yield {
+                "type": "pmessage",
+                "channel": b"__keyspace@6__:PSU_INFO|Psu2",
+                "data": b"hset",
+            }
+            await asyncio.Event().wait()
+            yield  # pragma: no cover - never reached
+
+        pubsub.listen = one_message_then_hang
+        conn = MagicMock()
+        conn.pubsub = MagicMock(return_value=pubsub)
+
+        with patch.object(trap_module.redis, 'from_url', return_value=conn):
+            task = self.loop.create_task(self.infra._reader_loop("redis"))
+
+            async def drive():
+                # Give the executor round trip time to complete.
+                await asyncio.sleep(0.1)
+                self.handler.trap_process.assert_called_once()
+                mock_protocol.send_pdu.assert_called_once()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            self.loop.run_until_complete(drive())
+
+
+class TestDbListener(TestCase):
+    """
+    db_listener() now only does setup (load config, compile/register
+    patterns) and launches one self-healing _reader_loop() task per redis
+    instance that actually has registered patterns - instances with no
+    patterns must not get a wasted reader task.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_creates_one_reader_task_per_instance_with_patterns(self):
+        pattern = "__keyspace@6__:PSU_INFO|*"
+        self.infra.dbKeyToHandler = {pattern: [MagicMock()]}
+
+        def fake_load_db_config():
+            self.infra.redis_instances = {
+                "redis": {
+                    "host": "127.0.0.1", "port": 6379,
+                    "keyPatterns": [], "patternObjs": [],
+                    "pubsub": None, "connection_obj": None,
+                },
+                "empty": {
+                    "host": "127.0.0.1", "port": 6380,
+                    "keyPatterns": [], "patternObjs": [],
+                    "pubsub": None, "connection_obj": None,
+                },
+            }
+            self.infra.db_to_redis_dict = {6: self.infra.redis_instances["redis"]}
+
+        with patch.object(self.infra, '_load_db_config', side_effect=fake_load_db_config), \
+             patch.object(self.infra, '_reader_loop', new_callable=AsyncMock) as mock_reader_loop:
+            self.loop.run_until_complete(self.infra.db_listener())
+            # AsyncMock resolves immediately; let the created task run to completion.
+            self.loop.run_until_complete(asyncio.gather(*self.infra._reader_tasks))
+
+        mock_reader_loop.assert_called_once_with("redis")
+        self.assertEqual(len(self.infra._reader_tasks), 1)
+        # The pattern was actually registered against the "redis" instance.
+        self.assertEqual(
+            self.infra.redis_instances["redis"]["patternObjs"], [pattern]
+        )
+
+
+class TestShutdown(TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_shutdown_cancels_readers_closes_connections_and_executor(self):
+        async def never_ending():
+            await asyncio.Event().wait()
+
+        task = self.loop.create_task(never_ending())
+        self.infra._reader_tasks = [task]
+
+        pubsub = MagicMock()
+        pubsub.punsubscribe = AsyncMock()
+        pubsub.close = AsyncMock()
+        conn = MagicMock()
+        conn.close = AsyncMock()
+
+        self.infra.redis_instances = {
+            "redis": {
+                "host": "127.0.0.1",
+                "port": 6379,
+                "keyPatterns": ["__keyspace@6__:PSU_INFO|*"],
+                "patternObjs": ["__keyspace@6__:PSU_INFO|*"],
+                "pubsub": pubsub,
+                "connection_obj": conn,
+            }
+        }
+
+        self.loop.run_until_complete(self.infra.shutdown())
+
+        self.assertTrue(task.cancelled())
+        pubsub.punsubscribe.assert_called_once()
+        pubsub.close.assert_called_once()
+        conn.close.assert_called_once()
+
+        # The executor must be shut down too - no new work can be scheduled.
+        with self.assertRaises(RuntimeError):
+            self.infra._executor.submit(lambda: None)
+
+    def test_shutdown_tolerates_punsubscribe_and_close_failures(self):
+        pubsub = MagicMock()
+        pubsub.punsubscribe = AsyncMock(side_effect=RuntimeError("punsubscribe failed"))
+        pubsub.close = AsyncMock(side_effect=RuntimeError("close failed"))
+        conn = MagicMock()
+        conn.close = AsyncMock(side_effect=RuntimeError("conn close failed"))
+
+        self.infra.redis_instances = {
+            "redis": {
+                "host": "127.0.0.1",
+                "port": 6379,
+                "keyPatterns": ["__keyspace@6__:PSU_INFO|*"],
+                "patternObjs": ["__keyspace@6__:PSU_INFO|*"],
+                "pubsub": pubsub,
+                "connection_obj": conn,
+            }
+        }
+
+        # None of the individual cleanup failures above should propagate.
+        self.loop.run_until_complete(self.infra.shutdown())
+
+        pubsub.punsubscribe.assert_called_once()
+        pubsub.close.assert_called_once()
+        conn.close.assert_called_once()
+
+
+class TestPatternHandling(TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_compile_patterns_matches_wildcard_keys_only_in_scope(self):
+        self.infra.dbKeyToHandler = {
+            "__keyspace@6__:PSU_INFO|*": [MagicMock()],
+        }
+        self.infra._compile_patterns()
+
+        cregex, handlers, original = self.infra._compiled_patterns[0]
+        self.assertTrue(cregex.fullmatch("__keyspace@6__:PSU_INFO|Psu2"))
+        self.assertFalse(cregex.fullmatch("__keyspace@6__:FAN_INFO|Fantray1_1"))
+        self.assertFalse(cregex.fullmatch("__keyspace@4__:PSU_INFO|Psu2"))
+
+    def test_register_pattern_requires_keyspace_prefix(self):
+        self.infra.db_to_redis_dict = {6: {"patternObjs": [], "keyPatterns": []}}
+        with self.assertRaises(RuntimeError):
+            self.infra._register_pattern("PSU_INFO|*")
+
+    def test_register_pattern_appends_to_matching_db_instance(self):
+        target = {"patternObjs": [], "keyPatterns": []}
+        self.infra.db_to_redis_dict = {6: target}
+
+        self.infra._register_pattern("__keyspace@6__:PSU_INFO|*")
+
+        self.assertEqual(target["patternObjs"], ["__keyspace@6__:PSU_INFO|*"])
+        self.assertEqual(target["keyPatterns"], ["__keyspace@6__:PSU_INFO|*"])
+
+    def test_invalid_compiled_pattern_is_logged_and_skipped(self):
+        """
+        re.escape() means a real invalid-regex pattern can't normally reach
+        re.compile() here, but the except re.error branch is still there as
+        a safety net - exercise it directly.
+        """
+        self.infra.dbKeyToHandler = {"__keyspace@6__:PSU_INFO|*": [MagicMock()]}
+
+        with patch.object(trap_module.re, 'compile', side_effect=re.error("bad pattern")):
+            self.infra._compile_patterns()
+
+        self.assertEqual(self.infra._compiled_patterns, [])
+
+
+class FakeTrapA(Trap):
+    def __init__(self):
+        super().__init__(dbKeys=["__keyspace@6__:PSU_INFO|*", "__keyspace@6__:FAN_INFO|*"])
+        self.trap_init_called = False
+
+    def trap_init(self):
+        self.trap_init_called = True
+
+
+class FakeTrapB(Trap):
+    def __init__(self):
+        super().__init__(dbKeys=["__keyspace@6__:PSU_INFO|*"])
+
+
+class TestInitTrapHandlers(TestCase):
+    """
+    TrapInfra(loop, trap_handlers) instantiates each handler class, indexes
+    it under every dbKey it declares, and calls trap_init() on it - this is
+    how link_up_down_trap/psu_fan_trap get wired up at startup.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_registers_handler_under_each_declared_dbkey_and_inits_it(self):
+        infra = TrapInfra(self.loop, [FakeTrapA])
+
+        self.assertIn("__keyspace@6__:PSU_INFO|*", infra.dbKeyToHandler)
+        self.assertIn("__keyspace@6__:FAN_INFO|*", infra.dbKeyToHandler)
+
+        handler = infra.dbKeyToHandler["__keyspace@6__:PSU_INFO|*"][0]
+        self.assertIsInstance(handler, FakeTrapA)
+        self.assertTrue(handler.trap_init_called)
+
+    def test_multiple_handlers_sharing_a_dbkey_are_all_registered(self):
+        infra = TrapInfra(self.loop, [FakeTrapA, FakeTrapB])
+
+        handlers = infra.dbKeyToHandler["__keyspace@6__:PSU_INFO|*"]
+        self.assertEqual(len(handlers), 2)
+        self.assertEqual({type(h) for h in handlers}, {FakeTrapA, FakeTrapB})
+
+    def test_trap_requires_dbkeys_list(self):
+        with self.assertRaises(TypeError):
+            Trap()
+
+
+class TestLoadDbConfig(TestCase):
+    """
+    _load_db_config() reads $DB_CONFIG_FILE (sonic-db's database_config.json
+    format) and builds redis_instances / db_to_redis_dict from it.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.infra = TrapInfra(self.loop, None)
+        self._env_patcher = None
+
+    def tearDown(self):
+        self.loop.close()
+        if self._env_patcher is not None:
+            self._env_patcher.stop()
+
+    def _use_config_file(self, content):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(content, tmp)
+        tmp.close()
+        self._env_patcher = patch.dict(os.environ, {"DB_CONFIG_FILE": tmp.name})
+        self._env_patcher.start()
+        self.addCleanup(os.unlink, tmp.name)
+
+    def test_missing_config_file_raises(self):
+        self._env_patcher = patch.dict(
+            os.environ, {"DB_CONFIG_FILE": "/nonexistent/database_config.json"}
+        )
+        self._env_patcher.start()
+
+        with self.assertRaises(RuntimeError):
+            self.infra._load_db_config()
+
+    def test_missing_instances_key_raises(self):
+        self._use_config_file({"DATABASES": {}})
+
+        with self.assertRaises(RuntimeError):
+            self.infra._load_db_config()
+
+    def test_database_referencing_unknown_instance_raises(self):
+        self._use_config_file({
+            "INSTANCES": {
+                "redis": {"hostname": "127.0.0.1", "port": 6379},
+            },
+            "DATABASES": {
+                "STATE_DB": {"id": 6, "instance": "does_not_exist"},
+            },
+        })
+
+        with self.assertRaises(RuntimeError):
+            self.infra._load_db_config()
+
+    def test_valid_config_populates_instances_and_db_mapping(self):
+        self._use_config_file({
+            "INSTANCES": {
+                "redis": {"hostname": "127.0.0.1", "port": 6379},
+                "redis_bmp": {"hostname": "127.0.0.1", "port": 6400},
+            },
+            "DATABASES": {
+                "STATE_DB": {"id": 6, "instance": "redis"},
+                "APPL_DB": {"id": 0, "instance": "redis"},
+            },
+        })
+
+        self.infra._load_db_config()
+
+        self.assertEqual(set(self.infra.redis_instances.keys()), {"redis", "redis_bmp"})
+        self.assertEqual(self.infra.redis_instances["redis"]["host"], "127.0.0.1")
+        self.assertEqual(self.infra.redis_instances["redis"]["port"], 6379)
+        self.assertIs(self.infra.db_to_redis_dict[6], self.infra.redis_instances["redis"])
+        self.assertIs(self.infra.db_to_redis_dict[0], self.infra.redis_instances["redis"])
+        # An instance with no DB mapped to it is still created, just unused.
+        self.assertNotIn(
+            self.infra.redis_instances["redis_bmp"],
+            self.infra.db_to_redis_dict.values(),
+        )
+
+
+class TestTrapBaseClassDefaults(TestCase):
+    """The default Trap.trap_init()/trap_process() are no-op hooks children
+    are expected to override; just confirm they exist and don't raise."""
+
+    def test_defaults_are_callable_and_return_none(self):
+        t = Trap(dbKeys=["__keyspace@6__:PSU_INFO|*"])
+        self.assertIsNone(t.trap_init())
+        self.assertIsNone(t.trap_process({}, "__keyspace@6__:PSU_INFO|Psu1"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added an asyncio-based SNMP Trap infrastructure (TrapInfra) to SONiC SNMP agent.
- Implemented native support for Link Up/Down and PSU / FAN SNMP traps.
- Generated traps as AgentX Notify PDUs carrying snmpTrapOID.0 and business varbinds, while keeping the final SNMP notification version and behavior (trap / inform) fully controlled by snmpd configuration.
- Ensured traps are triggered only on semantic state changes, preventing unnecessary trap storms.

**- How I did it**

**Introduced a generic TrapInfra layer that:**
- Subscribes to Redis keyspace notifications (multi-DB, multi-instance supported).
- Dispatches events to corresponding trap handlers using asyncio tasks.
- Wraps handler output into AgentX NotifyPDUs and forwards them to snmpd.

**Implemented dedicated trap handlers:**

1. Link Up/Down traps

- Trap OIDs: linkUp (1.3.6.1.6.3.1.1.5.4), linkDown (1.3.6.1.6.3.1.1.5.3)
- Varbinds: ifIndex, ifAdminStatus, ifOperStatus
- Interface index resolved via mibs.get_index_from_str(ifName)

2. PSU / FAN traps

- FAN Trap OID: 1.3.6.1.4.1.9.9.117.1.4.1.1.1
- PSU Trap OID: 1.3.6.1.4.1.9.9.117.1.1.2.1.2
- Index values derived deterministically from object names (PSU, FANTRAY)

All handlers compute varbinds based on state transitions, not raw field updates.
TrapInfra lifecycle is fully asyncio-managed and supports graceful shutdown.

**- How to verify it**

1. Configure SNMP trap destinations in snmpd.
2. Start snmpagent container and confirm TrapInfra subscriptions are active.
3. Trigger events on DUT:
Link state change (config interface shutdown/startup)
PSU or FAN state change (hardware event or simulated Redis update)
4. Verify:
SNMP notifications are sent as v1/v2c Notifications.
snmpTrapOID.0 matches the expected trap OID.
Varbind values (ifIndex, ifOperStatus, PSU/FAN status) are correct.
No duplicate traps are generated without actual semantic state changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add asyncio-based SNMP trap infrastructure with native support for link and PSU/FAN notifications.

#### Which release branch to backport (provide reason below if selected)

- [x] 202511

Reason for backport:
This change provides standard SNMP trap support (link, PSU, and FAN), which is required for basic device monitoring and NMS integration.
The implementation is self-contained, does not change existing SNMP behavior unless traps are explicitly configured, and is safe to include in 202511 releases.