### PR TITLE
rfc2737: check if entry is not empty before accessing it

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -888,6 +888,8 @@ class PsuCacheUpdater(PhysicalEntityCacheUpdater):
             return
 
         psu_relation_info = self.get_physical_relation_info(psu_name)
+        if not psu_relation_info:
+            return
         psu_position, psu_parent_name = get_db_data(psu_relation_info, PhysicalRelationInfoDB)
         psu_position = int(psu_position)
         psu_sub_id = get_psu_sub_id(psu_position)
@@ -1039,6 +1041,8 @@ class FanCacheUpdater(PhysicalEntityCacheUpdater):
             return
 
         fan_relation_info = self.get_physical_relation_info(fan_name)
+        if not fan_relation_info:
+            return
         fan_position, fan_parent_name = get_db_data(fan_relation_info, PhysicalRelationInfoDB)
         fan_position = int(fan_position)
         if fan_parent_name in self.mib_updater.physical_name_to_oid_map:

--- a/tests/test_rfc2737.py
+++ b/tests/test_rfc2737.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 import pytest
 from sonic_ax_impl.mibs.ietf.rfc2737 import PhysicalTableMIBUpdater
 from sonic_ax_impl.mibs.ietf.rfc2737 import FabricCardCacheUpdater
+from sonic_ax_impl.mibs.ietf.rfc2737 import FanCacheUpdater
+from sonic_ax_impl.mibs.ietf.rfc2737 import PsuCacheUpdater
 
 if sys.version_info.major == 3:
     from unittest import mock
@@ -161,3 +163,31 @@ class TestFabricCardCacheUpdater(TestCase):
             update_entity_cache('N/A')
             mocked_phy_contained_in.assert_called()
             mocked_set_phy_fru.assert_called()
+
+
+class TestPsuCacheUpdater(TestCase):
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"model": "PSU0", "serial": "S000", "current": "1.0", "power": "100.0", "presence": "True", "voltage": "12.0", "temp": "30.0", "is_replaceable": "True"})))
+    @mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalEntityCacheUpdater.get_physical_relation_info', mock.MagicMock(return_value=None))
+    def test_update_entity_cache_no_relation_info(self):
+        updater = PhysicalTableMIBUpdater()
+        psu_updater = PsuCacheUpdater(updater)
+
+        with (mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.add_sub_id') as mocked_add_sub_id,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.set_phy_contained_in') as mocked_set_phy_contained_in):
+            psu_updater._update_entity_cache('PSU 0')
+            mocked_add_sub_id.assert_not_called()
+            mocked_set_phy_contained_in.assert_not_called()
+
+
+class TestFanCacheUpdater(TestCase):
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"model": "FAN0", "presence": "True", "serial": "S000", "speed": "10000", "is_replaceable": "True"})))
+    @mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalEntityCacheUpdater.get_physical_relation_info', mock.MagicMock(return_value=None))
+    def test_update_entity_cache_no_relation_info(self):
+        updater = PhysicalTableMIBUpdater()
+        fan_updater = FanCacheUpdater(updater)
+
+        with (mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.add_sub_id') as mocked_add_sub_id,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.set_phy_contained_in') as mocked_set_phy_contained_in):
+            fan_updater._update_entity_cache('FAN 0')
+            mocked_add_sub_id.assert_not_called()
+            mocked_set_phy_contained_in.assert_not_called()


### PR DESCRIPTION
In `PsuCacheUpdater` and `FanCacheUpdater`, when we try to get
information of a PSU/Fan from Physical entity info table, we fail to check
whether there is no entry for that psu/fan in the table.

We see this issue in https://github.com/sonic-net/sonic-buildimage/issues/25652, where going
further without checking if there is no entry causes an exception in such
scenarios. This patch aims to fix that issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

