### PR TITLE
Fix early termination of SNMP walks when encountering None values

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -365,15 +365,16 @@ class MIBTable(dict):
     def _get_nextvalue(self, mib_entry, oid_key):
         sub_id = mib_entry.get_sub_id(oid_key)
         key1 = mib_entry.get_next(sub_id)
-        if key1 is None:
-            return None
-        val1 = mib_entry(key1)
-        if val1 is None:
-            return None
-        oid1 = mib_entry.replace_sub_id(oid_key, key1)
-        # OID found, call the OIDEntry
-        vr = ValueRepresentation.from_typecast(mib_entry.value_type, oid1, val1)
-        return vr
+        while key1 is not None:
+            val1 = mib_entry(key1)
+            if val1 is not None:
+                oid1 = mib_entry.replace_sub_id(oid_key, key1)
+                # OID found, call the OIDEntry
+                vr = ValueRepresentation.from_typecast(mib_entry.value_type, oid1, val1)
+                return vr
+            # Value is None, continue to the next sub_id
+            key1 = mib_entry.get_next(key1)
+        return None
 
     def get(self, sr, d=None):
         oid_key = sr.start.to_tuple()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes: https://github.com/sonic-net/sonic-snmpagent/issues/369
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/26489
**- What I did**
Fix SNMP GETNEXT skipping valid entries after encountering interface with missing counters

When _get_nextvalue() encounters an interface whose counters are not present in COUNTERS_DB (returning None), it returns immediately instead of advancing to the next sub_id. This causes SNMP walks (GETNEXT operations) to jump to the next MIB subtree, silently skipping all remaining valid entries such as PortChannel interfaces and such that could come after the ports without counter support in the OID ordering.

**- How I did it**
Fix by looping through subsequent sub_ids when a None value is encountered, returning only once a valid value is found or all entries are exhausted.

**- How to verify it**
The steps to reproduce that are mentioned in the actual Issue linked above, can be re-run with this fix.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

