### PR TITLE
Migrate CI pipeline from bookworm to trixie

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,24 +63,10 @@ stages:
         set -ex
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
-        # Ensure /usr/bin/python exists for [Auto] pipeline coverage extension
-        sudo ln -sf /usr/bin/python3 /usr/bin/python
         # Install diff-cover for [Auto] pipeline coverage extension
-        sudo apt-get install -y diff-cover
+        sudo pip3 install --break-system-packages --ignore-installed diff-cover
         python3 -m pytest
       displayName: "Unit tests"
-
-    - script: |
-        set -ex
-        echo "=== Debug: diff-cover availability ==="
-        which diff-cover || echo "diff-cover not in PATH"
-        python3 -m pip show diff-cover || echo "diff-cover not installed"
-        ls -la /usr/bin/python* || true
-        ls -la .diff-coverage/ || echo ".diff-coverage/ does not exist"
-        ls -la coverage.xml || echo "coverage.xml does not exist"
-        python3 --version
-        python --version || echo "python not found"
-      displayName: "Debug: check diff-cover and coverage state"
 
     - script: |
         set -ex

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
         # Ensure /usr/bin/python exists for [Auto] pipeline coverage extension
         sudo ln -sf /usr/bin/python3 /usr/bin/python
         # Install diff-cover for [Auto] pipeline coverage extension
-        sudo apt-get install -y python3-diff-cover || sudo pip3 install diff-cover > /dev/null
+        sudo apt-get install -y diff-cover
         python3 -m pytest
       displayName: "Unit tests"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,12 @@ stages:
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
         # Ensure /usr/bin/python exists for [Auto] pipeline coverage extension
         sudo ln -sf /usr/bin/python3 /usr/bin/python
+        # Install diff-cover for [Auto] pipeline coverage extension
+        if [ -n "$(which pip3)" ]; then
+          sudo pip3 install diff-cover > /dev/null
+        else
+          sudo pip install diff-cover > /dev/null
+        fi
         python3 -m pytest
       displayName: "Unit tests"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,8 +69,8 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/13/prod
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,9 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft-2025.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sSL https://packages.microsoft.com/keys/microsoft-2025.asc | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft-prod.gpg
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,10 +69,10 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
-        sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-8.0
+        curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+        chmod +x dotnet-install.sh
+        ./dotnet-install.sh --channel 8.0
+        export PATH="$HOME/.dotnet:$PATH"
       displayName: "Install .NET CORE"
 
     - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,8 @@ stages:
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
         # Install diff-cover for [Auto] pipeline coverage extension
-        sudo pip3 install --break-system-packages --ignore-installed diff-cover
+        sudo apt-get update
+        sudo apt-get install -y diff-cover
         python3 -m pytest
       displayName: "Unit tests"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,9 @@ stages:
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
         python3 -m pytest
+        # Generate diff-cover report for [Auto] pipeline extension
+        sudo python3 -m pip install diff-cover
+        diff-cover coverage.xml --compare-branch=origin/master --html-report .diff-coverage/diff-cover.html --json-report .diff-coverage/diff-cover.json --markdown-report .diff-coverage/diff-cover.md --diff-range-notation='..' || true
       displayName: "Unit tests"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
       vmImage: ubuntu-latest
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:latest
 
     steps:
     - checkout: self
@@ -50,10 +50,10 @@ stages:
     - script: |
         set -ex
         sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        sudo apt-get -y install libhiredis0.14
-        sudo dpkg -i ../target/debs/bookworm/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
-        sudo python3 -m pip install ../target/python-wheels/bookworm/swsssdk*-py3-*.whl
-        sudo python3 -m pip install ../target/python-wheels/bookworm/sonic_py_common-1.0-py3-none-any.whl
+        sudo apt-get -y install libhiredis1.1.0
+        sudo dpkg -i ../target/debs/trixie/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
+        sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl
+        sudo python3 -m pip install ../target/python-wheels/trixie/sonic_py_common-1.0-py3-none-any.whl
         python3 setup.py bdist_wheel
         cp dist/*.whl $(Build.ArtifactStagingDirectory)/
       displayName: "Build"
@@ -62,14 +62,14 @@ stages:
         set -ex
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
-        python3 setup.py test
+        python3 -m pytest
       displayName: "Unit tests"
 
     - script: |
         set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
+        sudo apt-add-repository https://packages.microsoft.com/debian/13/prod
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,8 @@ stages:
     - script: |
         set -ex
         sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        sudo apt-get -y install libhiredis1.1.0 libpcre3
+        sudo apt-get -y install libhiredis1.1.0
+        sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb
         sudo dpkg -i ../target/debs/trixie/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/trixie/sonic_py_common-1.0-py3-none-any.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,8 @@ stages:
         set -ex
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
+        # Ensure /usr/bin/python exists for [Auto] pipeline coverage extension
+        sudo ln -sf /usr/bin/python3 /usr/bin/python
         python3 -m pytest
       displayName: "Unit tests"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
     - script: |
         set -ex
         sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        sudo apt-get -y install libhiredis1.1.0
+        sudo apt-get -y install libhiredis1.1.0 libpcre3
         sudo dpkg -i ../target/debs/trixie/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/trixie/sonic_py_common-1.0-py3-none-any.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,11 +66,7 @@ stages:
         # Ensure /usr/bin/python exists for [Auto] pipeline coverage extension
         sudo ln -sf /usr/bin/python3 /usr/bin/python
         # Install diff-cover for [Auto] pipeline coverage extension
-        if [ -n "$(which pip3)" ]; then
-          sudo pip3 install diff-cover > /dev/null
-        else
-          sudo pip install diff-cover > /dev/null
-        fi
+        sudo apt-get install -y python3-diff-cover || sudo pip3 install diff-cover > /dev/null
         python3 -m pytest
       displayName: "Unit tests"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,18 @@ stages:
 
     - script: |
         set -ex
+        echo "=== Debug: diff-cover availability ==="
+        which diff-cover || echo "diff-cover not in PATH"
+        python3 -m pip show diff-cover || echo "diff-cover not installed"
+        ls -la /usr/bin/python* || true
+        ls -la .diff-coverage/ || echo ".diff-coverage/ does not exist"
+        ls -la coverage.xml || echo "coverage.xml does not exist"
+        python3 --version
+        python --version || echo "python not found"
+      displayName: "Debug: check diff-cover and coverage state"
+
+    - script: |
+        set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft-2025.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,9 +64,6 @@ stages:
 
         sudo python3 -m pip install dist/asyncsnmp-2.1.0-py3-none-any.whl
         python3 -m pytest
-        # Generate diff-cover report for [Auto] pipeline extension
-        sudo python3 -m pip install diff-cover
-        diff-cover coverage.xml --compare-branch=origin/master --html-report .diff-coverage/diff-cover.html --json-report .diff-coverage/diff-cover.json --markdown-report .diff-coverage/diff-cover.md --diff-range-notation='..' || true
       displayName: "Unit tests"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,10 +69,10 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
-        chmod +x dotnet-install.sh
-        ./dotnet-install.sh --channel 8.0
-        export PATH="$HOME/.dotnet:$PATH"
+        curl -sSL https://packages.microsoft.com/keys/microsoft-2025.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"
 
     - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,7 @@ stages:
 
     - script: |
         set -ex
-        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        sudo apt-get -y install libhiredis1.1.0
+        sudo apt-get -y purge libnl-3-dev libnl-route-3-dev
         sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb
         sudo dpkg -i ../target/debs/trixie/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl

--- a/tests/namespace/test_lldp.py
+++ b/tests/namespace/test_lldp.py
@@ -214,13 +214,13 @@ class TestLLDPMIB(TestCase):
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(1,))
-        self.assertEquals(ret, 'etp1')
+        self.assertEqual(ret, 'etp1')
         print(ret)
 
     def test_mgmt_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(10001,))
-        self.assertEquals(ret, 'mgmt1')
+        self.assertEqual(ret, 'mgmt1')
         print(ret)
 
     def test_getnextpdu_local_port_identification(self):

--- a/tests/test_PDUHeader.py
+++ b/tests/test_PDUHeader.py
@@ -198,7 +198,7 @@ class TestRegisterPDU(TestCase):
             for pdu in ps:
                 print(pdu)
         except exceptions.PDUUnpackError:
-            self.failIf('pdu' not in locals())
+            self.assertFalse('pdu' not in locals())
 
     def test_openPDU_stream(self):
         resp = b'\x01\x12\x10\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x00\x00\x00\xfe\x00\x00\x00\x00\x00\x04\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00CSoftware for Open Networking in the Cloud (SONiC) -- SNMP sub-agent\x00'
@@ -207,7 +207,7 @@ class TestRegisterPDU(TestCase):
             for pdu in ps:
                 print(pdu)
         except exceptions.PDUUnpackError:
-            self.failIf('pdu' not in locals())
+            self.assertFalse('pdu' not in locals())
 
 
 class TestGetPDU(TestCase):

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -1,4 +1,5 @@
 
+import importlib
 # noinspection PyUnresolvedReferences
 import tests.mock_tables.dbconnector
 from tests.mock_tables.dbconnector import SonicV2Connector
@@ -23,6 +24,9 @@ def mock_poll_lldp_notif(mock_lldp_polled_entries):
 class TestLLDPMIB(TestCase):
     @classmethod
     def setUpClass(cls):
+        tests.mock_tables.dbconnector.load_database_config()
+        importlib.reload(ieee802_1ab)
+
         class LLDPMIB(ieee802_1ab.LLDPLocalSystemData,
                       ieee802_1ab.LLDPLocalSystemData.LLDPLocPortTable,
                       ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable,

--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -201,13 +201,13 @@ class TestLLDPMIB(TestCase):
     def test_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(1,))
-        self.assertEquals(ret, 'etp1')
+        self.assertEqual(ret, 'etp1')
         print(ret)
 
     def test_mgmt_local_port_identification(self):
         mib_entry = self.lut[(1, 0, 8802, 1, 1, 2, 1, 3, 7, 1, 3)]
         ret = mib_entry(sub_id=(10001,))
-        self.assertEquals(ret, 'mgmt1')
+        self.assertEqual(ret, 'mgmt1')
         print(ret)
 
     def test_getnextpdu_local_port_identification(self):

--- a/tests/test_queues_stat.py
+++ b/tests/test_queues_stat.py
@@ -16,6 +16,7 @@ from sonic_ax_impl.mibs.vendor.cisco import ciscoSwitchQosMIB
 class TestQueueCounters(TestCase):
     @classmethod
     def setUpClass(cls):
+        tests.mock_tables.dbconnector.load_database_config()
         cls.lut = MIBTable(ciscoSwitchQosMIB.csqIfQosGroupStatsTable)
         # Update MIBs
         for updater in cls.lut.updater_instances:

--- a/tests/test_queues_stat.py
+++ b/tests/test_queues_stat.py
@@ -1,4 +1,5 @@
 
+import importlib
 # noinspection PyUnresolvedReferences
 import tests.mock_tables.dbconnector
 
@@ -11,12 +12,18 @@ from ax_interface.encodings import ObjectIdentifier
 from ax_interface.constants import PduTypes
 from ax_interface.pdu import PDU, PDUHeader
 from ax_interface.mib import MIBTable
+from sonic_ax_impl import mibs
 from sonic_ax_impl.mibs.vendor.cisco import ciscoSwitchQosMIB
 
 class TestQueueCounters(TestCase):
     @classmethod
     def setUpClass(cls):
         tests.mock_tables.dbconnector.load_database_config()
+        # Reset Namespace cache and reload modules to clear any
+        # multi-namespace state left by previously-run namespace tests
+        # (pytest 8+ does not guarantee test file ordering).
+        mibs.Namespace.db_config_loaded = False
+        importlib.reload(ciscoSwitchQosMIB)
         cls.lut = MIBTable(ciscoSwitchQosMIB.csqIfQosGroupStatsTable)
         # Update MIBs
         for updater in cls.lut.updater_instances:


### PR DESCRIPTION
**- What I did**
Migrated the Azure Pipelines CI from the bookworm slave container to trixie.

**- How I did it**
- **Container image**: `sonic-slave-bookworm:latest` → `sonic-slave-trixie:latest`
- **Artifact paths**: `debs/bookworm/` → `debs/trixie/`, `python-wheels/bookworm/` → `python-wheels/trixie/`
- **hiredis**: `libhiredis0.14` → `libhiredis1.1.0` (trixie ships hiredis 1.1.0)
- **Unit tests**: `python3 setup.py test` → `python3 -m pytest` (setup.py test is deprecated)
- **.NET repo**: `packages.microsoft.com/debian/12/prod` → `debian/13/prod`

**- How to verify it**
CI pipeline should pass with trixie slave and trixie artifacts.

**- Description for the changelog**
Migrate CI pipeline from bookworm to trixie slave container and artifacts.