### PR TITLE
azure-pipelines: install libyang3 instead of libyang1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
         set -ex
         sudo apt-get -y purge libnl-3-dev libnl-route-3-dev
         sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb
-        sudo dpkg -i ../target/debs/trixie/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
+        sudo dpkg -i ../target/debs/trixie/{libyang3_*.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/trixie/sonic_py_common-1.0-py3-none-any.whl
         python3 setup.py bdist_wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,6 @@ stages:
     - script: |
         set -ex
         sudo apt-get -y purge libnl-3-dev libnl-route-3-dev
-        sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb
         sudo dpkg -i ../target/debs/trixie/{libyang3_*.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/trixie/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/trixie/sonic_py_common-1.0-py3-none-any.whl


### PR DESCRIPTION
**- What I did**

Updated `azure-pipelines.yml` to install the libyang3 deb (`libyang3_*.deb`) instead of the removed libyang1 deb (`libyang_1.0.73_amd64.deb`) in the dependency install step.

**- How I did it**

`sonic-buildimage` now builds only libyang3, so the `libyang_1.0.73_amd64.deb` token in the brace-expanded `dpkg -i {...}` list was replaced with the versionless glob `libyang3_*.deb` (consistent with the existing `libpcre3_*.deb` / `libnl-*_*.deb` globs in the same list). Part of sonic-net/sonic-buildimage#22385.

**- How to verify it**

The CI dependency install succeeds against the libyang3 debs produced by current `sonic-buildimage` master; a re-grep shows the only libyang reference is now `libyang3_*.deb`.

**- Description for the changelog**

azure-pipelines: install libyang3 instead of libyang1.
