### PR TITLE
[github]: Add backport test evidence sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,53 @@ Please provide the following information:
 
 **- How to verify it**
 
+**- Which release branch to backport (provide reason below if selected)**
+<!--
+- Note we only backport fixes to a release branch, *not* features!
+- A backport/cherry-pick request requires a GitHub issue or Microsoft ADO
+  work item describing the failure (day-one issue, regression, or other)
+  and test evidence from the target branch(es) selected below.
+- Please also provide a reason for the backporting below.
+- e.g.
+- [x] 202605
+-->
+
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+
+Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
+Failure type: <!-- day-one issue / regression / other -->
+
+**- Tested branch**
+<!--
+- Select each branch where the change was tested.
+- If you request a backport/cherry-pick, select the base branch and the
+  tested target release branch(es).
+-->
+
+- [ ] master
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+- [ ] N/A
+
+**- Test result**
+<!--
+- Provide the tested image version and test evidence for each selected branch.
+- e.g.
+- master: 20260716.01 - <test result or link>
+- 202605: 20260531.42 - <test result or link>
+-->
+
 **- Description for the changelog**
 <!--
 Write a short (one line) summary that describes the changes in this


### PR DESCRIPTION
**- What I did**

Template-only change: updated `.github/PULL_REQUEST_TEMPLATE.md` to add the
same backport/cherry-pick validation structure introduced in
sonic-net/sonic-buildimage#28464 and sonic-net/sonic-mgmt#26279, adapted to
this repo's existing minimal legacy template (bold-label style).

**- How I did it**

Inserted, between the existing `**- How to verify it**` and
`**- Description for the changelog**` sections, three new visible sections
while preserving all existing labels and the compact style:
- `**- Which release branch to backport (provide reason below if selected)**`
  with unchecked checkboxes for the seven currently active release branches
  (202305, 202311, 202405, 202411, 202505, 202511, 202605), hidden
  instructions stating that a backport/cherry-pick request requires a
  GitHub issue or Microsoft ADO work item describing the failure plus
  target-branch test evidence, and visible tracking issue/work item and
  failure type fields.
- `**- Tested branch**` with hidden instructions and checkboxes for master,
  the same seven release branches, and N/A.
- `**- Test result**` asking for the tested image/build version and test
  evidence for every selected branch, with examples for master and 202605.

No automation code, labels, or unrelated changes were added.

**- How to verify it**

- Reviewed the rendered Markdown structure and confirmed `**- What I did**`,
  `**- How I did it**`, `**- How to verify it**`, and
  `**- Description for the changelog**` are unchanged and preserved.
- Ran `git diff --check` on the change (clean, no whitespace errors).
- Manually confirmed the new sections render correctly as a GitHub PR
  template preview and that checkbox syntax (`- [ ] `) is valid.
- This is a template-only, docs-only change; no backport of this change
  itself is requested.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Not requesting a backport — this is a template/documentation-only change
that only needs to land on `master`.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A (template/documentation change, not a bug fix)

**- Tested branch**

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [x] N/A

**- Test result**

N/A — this PR only changes `.github/PULL_REQUEST_TEMPLATE.md` (a GitHub
Markdown template file), it contains no executable code, so there is no
image/build to test. Validation performed was `git diff --check` plus a
manual Markdown/rendering review as described above.

**- Description for the changelog**

Add backport/cherry-pick test-evidence sections (release checklist,
tracking issue/work item, tested branch, and test result) to the PR
template, matching sonic-net/sonic-buildimage#28464 and
sonic-net/sonic-mgmt#26279.

---
Related: sonic-net/sonic-buildimage#28464, sonic-net/sonic-mgmt#26279
